### PR TITLE
Added: info about user while delete network bridge

### DIFF
--- a/openvair/modules/network/service_layer/services.py
+++ b/openvair/modules/network/service_layer/services.py
@@ -421,8 +421,8 @@ class NetworkServiceLayerManager(BackgroundTasks):
             exceptions.InterfaceDeletingError: If an error occurs during the
                 RPC call to the domain layer.
         """
-        user_info = data.get('user_data', {})
-        user_id = user_info.get('user_id', '')
+        user_info = data.get('user_info', {})
+        user_id = user_info.get('id', '')
         iface_id = data.get('id')
 
         with self.uow:


### PR DESCRIPTION
## Название: Добавить ID пользователя при удалении сетей

### Описание изменений:
- Изменена логика получения информации о пользователе при удалении сетей:
  - Изменено название ключа: вместо `user_data['user_id']` теперь используется `user_info['id']`.
  
### Детали:
- Это изменение улучшает получение идентификатора пользователя, гарантируя правильное извлечение ID из объекта `user_info` в процессе удаления сетевого интерфейса.
  
### Измененные файлы:
- `openvair/modules/network/service_layer/services.py`

### Контекст:
- Этот PR решает проблему неправильного доступа к ID пользователя в данных, переданных при удалении сети, что необходимо для корректного функционирования данного процесса.
