### PR TITLE
Fixed: NFS available storages regular expression

### DIFF
--- a/openvair/modules/storage/domain/remotefs/nfs.py
+++ b/openvair/modules/storage/domain/remotefs/nfs.py
@@ -125,7 +125,7 @@ class NfsStorage(RemoteFSStorage):
             message = f'Nfs ip {self.ip} is not available'
             LOG.error(message)
             raise NfsIpIsNotAvailableError(message)
-        available_paths = re.findall(r'\n(.*?)\s', output)
+        available_paths = re.findall(r'/([^ ]+)\s+\*', output)
         if self.path not in available_paths:
             message = f"Nfs doesn't have current path {self.path}."
             LOG.error(message)


### PR DESCRIPTION
## Название: При подключении NFS хранилища получаем ошибку `Nfs doesn't have current path <NFS path>`

### Описание изменений:
- Исправлено регулярное выражение для извлечения доступных путей NFS, что устраняет ошибку при подключении хранилища.

### Детали:
- Изменено регулярное выражение на `r'/([^ ]+)\s+\*'`, что позволяет корректно извлекать пути, доступные для NFS, и предотвращает возникновение ошибки `Nfs doesn't have current path <NFS path>`.

### Измененные файлы:
- `openvair/modules/storage/domain/remotefs/nfs.py`

### Контекст:
- Этот PR решает проблему с подключением NFS хранилища, улучшая обработку доступных путей и обеспечивая корректную работу системы хранения.