### PR TITLE
Обновление функции validate_objects в связи с переходом на Pydantic v2 

### DIFF
--- a/openvair/modules/event_store/entrypoints/crud.py
+++ b/openvair/modules/event_store/entrypoints/crud.py
@@ -54,8 +54,7 @@ class EventCrud:
                 DataSerializer.to_web(event)
                 for event in self.uow.events.get_all()
             ]
-            validate_objects(web_events, schemas.Event)
-            return web_events
+            return validate_objects(web_events, schemas.Event)
 
     def get_all_events_by_module(self) -> List:
         """Retrieve all events by module from the database.

--- a/openvair/modules/storage/entrypoints/api.py
+++ b/openvair/modules/storage/entrypoints/api.py
@@ -18,11 +18,11 @@ Entrypoints:
     DELETE /storages/{storage_id}/delete/ - Delete a storage by its ID.
 """
 
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 
 from fastapi import Path, Depends, APIRouter, status
 from fastapi.responses import JSONResponse
-from fastapi_pagination import Page
+from fastapi_pagination import Page, paginate
 from starlette.concurrency import run_in_threadpool
 
 from openvair.libs.log import get_logger
@@ -48,7 +48,7 @@ router = APIRouter(
 )
 async def get_storages(
     crud: StorageCrud = Depends(StorageCrud),
-) -> Page:
+) -> Page[schemas.Storage]:
     """It gets a list of storages from the database
 
     Args:
@@ -60,7 +60,7 @@ async def get_storages(
     LOG.info('Api start getting list of storages')
     storages = await run_in_threadpool(crud.get_all_storages)
     LOG.info('Api request was successfully processed.')
-    return storages
+    return cast(Page, paginate(storages))
 
 
 @router.get(

--- a/openvair/modules/storage/entrypoints/crud.py
+++ b/openvair/modules/storage/entrypoints/crud.py
@@ -9,9 +9,7 @@ Classes:
         and partitions.
 """
 
-from typing import Dict, List, cast
-
-from fastapi_pagination import Page, paginate
+from typing import Dict, List
 
 from openvair.libs.log import get_logger
 from openvair.modules.tools.utils import validate_objects
@@ -53,7 +51,7 @@ class StorageCrud:
         LOG.debug('Response from service layer: %s.' % result)
         return result
 
-    def get_all_storages(self) -> Page:
+    def get_all_storages(self) -> List[schemas.BaseModel]:
         """Retrieve all storages from the database.
 
         Returns:
@@ -65,8 +63,7 @@ class StorageCrud:
             data_for_method={},
         )
         LOG.debug('Response from service layer: %s.' % result)
-        storages = validate_objects(result, schemas.Storage)
-        return cast(Page, paginate(storages))
+        return validate_objects(result, schemas.Storage)
 
     def create_storage(self, data: Dict, user_data: Dict) -> Dict:
         """Create a new storage.
@@ -128,7 +125,7 @@ class StorageCrud:
         )
         LOG.debug('Response from service layer: %s.' % result)
         local_disks = validate_objects(result, schemas.LocalDisk)
-        return schemas.ListOfLocalDisks(disks=local_disks)
+        return schemas.ListOfLocalDisks.model_validate({'disks': local_disks})
 
     def create_local_partition(self, data: Dict, user_data: Dict) -> Dict:
         """Create a new partition on a local disk.

--- a/openvair/modules/tools/utils.py
+++ b/openvair/modules/tools/utils.py
@@ -45,6 +45,7 @@ from typing import (
     Any,
     Dict,
     List,
+    Type,
     Tuple,
     Union,
     Optional,
@@ -719,6 +720,7 @@ def xml_to_jsonable(xml_string: str) -> Union[Dict, List]:
     # Парсим XML и убираем префиксы
     parsed_dict = xmltodict.parse(xml_string)
     return remove_prefix(parsed_dict)
+
 
 @contextmanager
 def change_directory(

--- a/openvair/modules/tools/utils.py
+++ b/openvair/modules/tools/utils.py
@@ -643,7 +643,7 @@ def validate_objects(
             )
             LOG.warning(message)
             if skip_corrupted_object:
-                corrupted_object: BaseModel = pydantic_schema.model_validate(
+                corrupted_object: BaseModel = pydantic_schema.model_construct(
                     **_create_corrupted_data(pydantic_schema, _object)
                 )
                 result.append(corrupted_object)

--- a/openvair/modules/virtual_machines/entrypoints/crud.py
+++ b/openvair/modules/virtual_machines/entrypoints/crud.py
@@ -69,8 +69,7 @@ class VMCrud:
             data_for_method={},
         )
         LOG.debug('Response from service layer: %s.', result)
-        vms: List = validate_objects(result, schemas.VirtualMachineInfo)
-        return vms
+        return validate_objects(result, schemas.VirtualMachineInfo)
 
     def create_vm(self, data: Dict, user_info: Dict) -> Dict:
         """Create a new virtual machine.


### PR DESCRIPTION
### **Основные изменения**

- **Выделена вспомогательная функция `_create_corrupted_data`**
  - Вынесена логика создания "corrupted object" из `validate_objects`, что улучшает читаемость и переиспользуемость кода.
  - Теперь формирование "испорченных" данных выполняется отдельно, с учётом полей модели Pydantic.

- **Обновлена функция `validate_objects`**
  - Вместо старого способа инициализации моделей (`pydantic_schema(**_object)`) теперь используется `model_validate()`, что соответствует Pydantic v2.
  - Для обработки некорректных данных теперь используется `TypeAdapter`, что улучшает корректность значений.
  - Исключения `TypeError`, `ValueError`, `AssertionError` заменены на `ValidationError`.
  - Добавлено более подробное описание поведения функции `validate_objects` в docstring.

- **Обновлён метод `get_all_storages` в `StorageCrud`**
  - Убрано преобразование результата в `Page`, теперь метод возвращает `List[schemas.BaseModel]`, что соответствует его логике.
  - Убраны ненужные `cast()` из кода.

- **Рефакторинг мест использования `validate_objects`**
  - В модулях `event_store`, `storage`, `virtual_machines` упрощены вызовы `validate_objects` без лишних промежуточных переменных.
  - Теперь `validate_objects` вызывается и сразу возвращает результат.

- **Использование `model_validate()` в `ListOfLocalDisks`**
  - В `get_local_disks` теперь используется  
    ```python
    schemas.ListOfLocalDisks.model_validate({'disks': local_disks})
    ```  
    вместо создания объекта через `**kwargs`, что улучшает совместимость с Pydantic v2.

---

### **Поведение системы**

- **Корректные объекты:**
  - Валидируются и возвращаются без изменений.

- **Некорректные объекты:**
  - Теперь обрабатываются вспомогательной функцией `_create_corrupted_data`.
  - Если `skip_corrupted_object=True`, объект получает `"corrupted object"` в поле `status` и безопасные значения для других полей.
  - Если `skip_corrupted_object=False`, выбрасывается `ValidationError`.

---

### **Инструкции для тестирования**

1. Проверить валидацию данных в методах:
   - `get_all_storages`
   - `get_all_events`
   - `get_all_vms`

2. Создать тестовые данные с некорректными значениями и проверить:
   - Правильное создание `"corrupted object"` через `_create_corrupted_data`.
   - Срабатывает ли `ValidationError`, если `skip_corrupted_object=False`.

3. Проверить корректность работы с Pydantic v2:
   - Вызовы `model_validate()` работают без ошибок.

---

### **Преимущества**

- Выделение `_create_corrupted_data` делает код чище и удобнее для расширения.
- Полная поддержка Pydantic v2.
- Улучшенное логирование и обработка ошибок при валидации.
- Отказ от лишнего преобразования в `Page`, соответствие реальной логике методов.
