### PR TITLE
Миграция модуля block_device на новую версию execute

### DIFF
--- a/openvair/modules/block_device/domain/fibre_channel/fibre_channel.py
+++ b/openvair/modules/block_device/domain/fibre_channel/fibre_channel.py
@@ -15,8 +15,6 @@ Classes:
         devices.
 """
 
-from typing import Any
-
 from openvair.libs.log import get_logger
 from openvair.modules.tools.utils import lip_scan as utils_lip_scan
 from openvair.modules.block_device.domain.base import BaseFibreChannel
@@ -35,7 +33,7 @@ class FibreChannelInterface(BaseFibreChannel):
     adapters.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401 # TODO need to parameterize the arguments correctly, in accordance with static typing
+    def __init__(self) -> None:
         """Initialize a FibreChannelInterface object.
 
         Args:
@@ -44,7 +42,7 @@ class FibreChannelInterface(BaseFibreChannel):
             **kwargs: Keyword arguments passed to the `BaseFibreChannel`
                 constructor.
         """
-        super().__init__(*args, **kwargs)
+        super().__init__()
 
     def lip_scan(self) -> str:
         """Perform a LIP (Loop Initialization Procedure) scan.

--- a/openvair/modules/block_device/domain/model.py
+++ b/openvair/modules/block_device/domain/model.py
@@ -70,5 +70,7 @@ class InterfaceFactory(AbstractInterfaceFactory):
         Raises:
             KeyError: If the corresponding interface type is not found.
         """
-        interface_class = self._interface_classes[interface_data['inf_type']]
+        interface_class = self._interface_classes[
+            interface_data.pop('inf_type')
+        ]
         return cast(BaseBlockInterface, interface_class(**interface_data))


### PR DESCRIPTION
## **Описание изменений**

### **Основные изменения**

#### **1. Переход на новую версию `execute`**
- Используется обновлённая функция `execute` из `openvair.libs.cli.executor`.
- Теперь выполнение команд через `execute` использует `ExecuteParams`, что позволяет:
  - Управлять параметрами (`run_as_root=True`, `shell=True`, `raise_on_error=True`).
  - Избавиться от устаревшего механизма проверки ошибок (раньше использовалась проверка `error`).
  - Исключения теперь корректно перехватываются через `try-except` с `ExecuteError`, а ошибки логируются.

#### **2. Исправление ошибки при инициализации `FibreChannelInterface`**
Во время тестирования возникла ошибка:
```plaintext
object.__init__() takes exactly one argument (the instance to initialize)
```
**Причина:**  
Конструктор `FibreChannelInterface` вызывал `super().__init__(*args, **kwargs)`, но `BaseFibreChannel` не ожидает аргументов.

**Исправление:**  
Теперь `super().__init__()` вызывается без аргументов, что устраняет проблему.

#### **3. Исправление ошибки при передаче `inf_type` в `InterfaceFactory`**
- Ранее `inf_type` передавался в конструктор `FibreChannelInterface`, который не принимает параметры.
- Теперь `inf_type` корректно удаляется из `interface_data` через `.pop('inf_type')` перед созданием объекта интерфейса.

#### **4. Рефакторинг работы с iSCSI-интерфейсом (`ISCSIInterface`)**
- Методы `get_host_iqn`, `discovery`, `login`, `logout` переведены на новый `execute`.

---

## **Требования к тестированию**

### **1. Проверка выполнения команд iSCSI (`ISCSIInterface`)**
- Вызвать:
  - `get_host_iqn()`
  - `discovery()`
  - `login()`
  - `logout()`
- Убедиться, что ошибки выполнения корректно логируются и вызывают исключения:
  - `ISCSIGetIQNException`
  - `ISCSIDiscoveryError`
  - `ISCSILoginError`
  - `ISCSILogoutError`

### **2. Проверка создания `FibreChannelInterface`**
- Убедиться, что конструктор корректно вызывается без аргументов.

### **3. Проверка создания интерфейсов через `InterfaceFactory`**
- Передавать `interface_data` с `inf_type` и без него, убедиться, что `.pop('inf_type')` корректно удаляет параметр перед созданием объекта.

---

## **Критерии приёмки**
✔ Исправлена ошибка при инициализации `FibreChannelInterface`.  
✔ Перевод кода на актуальную версию `execute` с параметрами.  
✔ Улучшена обработка ошибок выполнения команд.  
✔ Устранены потенциальные конфликты при передаче `inf_type` в `InterfaceFactory`.  
✔ Код стал чище и стабильнее.  
