### PR TITLE
Миграция модуля `image` на новую версию execute

### DIFF
--- a/openvair/modules/image/domain/physical_fs/localfs.py
+++ b/openvair/modules/image/domain/physical_fs/localfs.py
@@ -55,8 +55,8 @@ class LocalFSImage(BaseLocalFSImage):
                 'convert',
                 '-f raw',
                 '-O qcow2',
-                image_tmp,  # type: ignore
-                image_path,  # type: ignore
+                str(image_tmp),  # type: ignore
+                str(image_path),  # type: ignore
                 params=ExecuteParams(
                     run_as_root=self._execute_as_root,
                     raise_on_error=True

--- a/openvair/modules/image/domain/physical_fs/localfs.py
+++ b/openvair/modules/image/domain/physical_fs/localfs.py
@@ -57,7 +57,8 @@ class LocalFSImage(BaseLocalFSImage):
                 '-O qcow2',
                 str(image_tmp),  # type: ignore
                 str(image_path),  # type: ignore
-                params=ExecuteParams(
+                params=ExecuteParams(  # noqa: S604
+                    shell=True,
                     run_as_root=self._execute_as_root,
                     raise_on_error=True
                 )

--- a/openvair/modules/image/domain/physical_fs/localfs.py
+++ b/openvair/modules/image/domain/physical_fs/localfs.py
@@ -55,8 +55,8 @@ class LocalFSImage(BaseLocalFSImage):
                 'convert',
                 '-f raw',
                 '-O qcow2',
-                str(image_tmp),  # type: ignore
-                str(image_path),  # type: ignore
+                str(image_tmp),
+                str(image_path),
                 params=ExecuteParams(  # noqa: S604
                     shell=True,
                     run_as_root=self._execute_as_root,
@@ -87,6 +87,7 @@ class LocalFSImage(BaseLocalFSImage):
             self._check_image_exists()
         except Exception as _:
             LOG.exception("LocalFSImage doesn't exist on storage.")
+            raise
         else:
             try:
                 image_path = f'{self.path}/image-{self.id}'
@@ -120,12 +121,12 @@ class LocalFSImage(BaseLocalFSImage):
             execute(
                 'rm',
                 '-f',
-                image_tmp,
+                str(image_tmp),
                 params=ExecuteParams(
                     run_as_root=self._execute_as_root,
                     raise_on_error=True
                 )
-            )  # type: ignore
+            )
         except (ExecuteError, OSError) as err:
             msg = (
                 f'Failed to delete image with ID {self.id} '

--- a/openvair/modules/image/domain/physical_fs/localfs.py
+++ b/openvair/modules/image/domain/physical_fs/localfs.py
@@ -93,7 +93,7 @@ class LocalFSImage(BaseLocalFSImage):
                 image_path = Path(self.path, f'image-{self.id}')
                 execute(
                     'rm', '-f',
-                    image_path,
+                    str(image_path),
                     params=ExecuteParams(
                         run_as_root=self._execute_as_root,
                         raise_on_error=True

--- a/openvair/modules/image/domain/physical_fs/localfs.py
+++ b/openvair/modules/image/domain/physical_fs/localfs.py
@@ -90,7 +90,7 @@ class LocalFSImage(BaseLocalFSImage):
             raise
         else:
             try:
-                image_path = f'{self.path}/image-{self.id}'
+                image_path = Path(self.path, f'image-{self.id}')
                 execute(
                     'rm', '-f',
                     image_path,

--- a/openvair/modules/image/domain/remotefs/nfs.py
+++ b/openvair/modules/image/domain/remotefs/nfs.py
@@ -55,9 +55,10 @@ class NfsImage(BaseRemoteFSImage):
                 'convert',
                 '-f raw',
                 '-O qcow2',
-                image_tmp,  # type: ignore
-                image_path,  # type: ignore
-                params=ExecuteParams(
+                str(image_tmp),  # type: ignore
+                str(image_path),  # type: ignore
+                params=ExecuteParams(  # noqa: S604
+                    shell=True,
                     run_as_root=self._execute_as_root,
                     raise_on_error=True
                 )

--- a/openvair/modules/image/domain/remotefs/nfs.py
+++ b/openvair/modules/image/domain/remotefs/nfs.py
@@ -55,8 +55,8 @@ class NfsImage(BaseRemoteFSImage):
                 'convert',
                 '-f raw',
                 '-O qcow2',
-                str(image_tmp),  # type: ignore
-                str(image_path),  # type: ignore
+                str(image_tmp),
+                str(image_path),
                 params=ExecuteParams(  # noqa: S604
                     shell=True,
                     run_as_root=self._execute_as_root,
@@ -114,7 +114,7 @@ class NfsImage(BaseRemoteFSImage):
             execute(
                 'rm',
                 '-f',
-                image_tmp,
+                str(image_tmp),
                 params=ExecuteParams(
                     run_as_root=self._execute_as_root,
                     raise_on_error=True

--- a/openvair/modules/image/domain/remotefs/nfs.py
+++ b/openvair/modules/image/domain/remotefs/nfs.py
@@ -81,12 +81,13 @@ class NfsImage(BaseRemoteFSImage):
             Dict: A dictionary containing the image's attributes.
         """
         LOG.info('Deleting NFSImage...')
-        image_path = f'{self.path}/image-{self.id}'
+        image_path = Path(self.path, f'image-{self.id}')
+
         try:
             execute(
                 'rm',
                 '-f',
-                image_path,
+                str(image_path),
                 params=ExecuteParams(
                     run_as_root=self._execute_as_root,
                     raise_on_error=True


### PR DESCRIPTION
# Описание изменений

Обновлена логика выполнения команд в `LocalFSImage` и `NfsImage`, добавлена обработка ошибок, улучшена детализация логирования.

---

# Основные изменения

- Заменён импорт `execute` из `openvair.modules.tools.utils` на `openvair.libs.cli.executor.execute`.
- Добавлены новые импорты:
  - `ExecuteParams` из `openvair.libs.cli.models`
  - `ExecuteError` из `openvair.libs.cli.exceptions`
- В `LocalFSImage`:
  - Улучшена обработка ошибок при конвертации образов (`qemu-img convert`).
  - Добавлена подробная логика обработки исключений `ExecuteError` и `OSError` при загрузке, удалении и очистке временных файлов.
  - Использование `ExecuteParams` для настройки выполнения команд с `run_as_root` и `raise_on_error`.
- В `NfsImage`:
  - Аналогичные изменения внесены в методы конвертации, удаления и очистки временных файлов.
  - Улучшена логика логирования, включая успешное завершение операций.

---

# Требования к тестированию

1. **Проверка конвертации образа**
   - Запустить процесс загрузки образа и убедиться, что конвертация выполняется без ошибок.
   - В случае ошибки должны логироваться корректные сообщения об исключении `ExecuteError` или `OSError`.
   
2. **Проверка удаления образа**
   - Удалить образ через `LocalFSImage` и `NfsImage`.
   - Убедиться, что команда `rm` выполняется с `ExecuteParams`.
   - В случае ошибки (`ExecuteError` или `OSError`) должно появляться сообщение в логах.

3. **Проверка очистки временных файлов**
   - Вызвать `delete_from_tmp` и убедиться, что файлы корректно удаляются.
   - Лог должен содержать сообщения о начале и успешном завершении операции.

---

# Критерии приёмки

- Все изменения не нарушают текущий функционал.
- Исключения корректно обрабатываются и логируются.
- `ExecuteParams` используется для всех вызовов `execute`.
- Все тесты проходят успешно.

---

# Заключение

Данный Pull Request улучшает стабильность работы с образами, обеспечивая надёжную обработку ошибок и более детальное логирование.
