### PR TITLE
Добавление функционала удаления бекапа

### DIFF
--- a/openvair/modules/backup/adapters/restic/restic.py
+++ b/openvair/modules/backup/adapters/restic/restic.py
@@ -8,7 +8,7 @@ Classes:
 """
 
 import json
-from typing import Dict, List, Union, Optional
+from typing import Dict, List, Union
 from pathlib import Path
 
 from openvair.libs.log import get_logger
@@ -75,7 +75,6 @@ class ResticAdapter:
             self._check_result(
                 self.INIT_SUBCOMMAND,
                 result,
-                ReturnCode.from_code(result.returncode),
             )
         except ResticError as err:
             actual_error = ResticInitRepoError(f'{err!s}')
@@ -119,7 +118,6 @@ class ResticAdapter:
             self._check_result(
                 self.BACKUP_SUBCOMMAND,
                 result,
-                ReturnCode.from_code(result.returncode),
             )
         except ResticError as err:
             actual_error = ResticBackupError(f'{err!s}')
@@ -156,7 +154,6 @@ class ResticAdapter:
         self._check_result(
             self.SNAPSHOTS_SUBCOMMAND,
             result,
-            ReturnCode.from_code(result.returncode),
         )
 
         snapshots_info: List[Dict[str, Union[str, int]]] = json.loads(
@@ -198,7 +195,6 @@ class ResticAdapter:
             self._check_result(
                 self.BACKUP_SUBCOMMAND,
                 result,
-                ReturnCode.from_code(result.returncode),
             )
         except ResticError as err:
             actual_error = ResticRestoreError(f'{err!s}')
@@ -212,19 +208,18 @@ class ResticAdapter:
         self,
         operation: str,
         result: ExecutionResult,
-        return_code: Optional[ReturnCode],
     ) -> None:
         """Checks the result of a restic command and validates its success.
 
         Args:
             operation (str): The operation being performed (e.g., "backup").
             result (ExecutionResult): The result of the executed command.
-            return_code (Optional[ReturnCode]): The return code of the command.
 
         Raises:
             ResticError: If the command result is unsuccessful or the return
                 code indicates failure.
         """
+        return_code = ReturnCode.from_code(result.returncode)
         if return_code is None or return_code != ReturnCode.SUCCESS:
             description = (
                 return_code.description if return_code else 'Unknown exit code'

--- a/openvair/modules/backup/adapters/restic/restic.py
+++ b/openvair/modules/backup/adapters/restic/restic.py
@@ -206,13 +206,21 @@ class ResticAdapter:
         return restore_info
 
     def forget(self, snapshot_id: str) -> Dict[str, Union[str, int]]:
-        """_summary_
+        """Remove a specific snapshot from the restic repository.
+
+        This method executes the `forget --prune` command to delete a given
+        snapshot from the repository, ensuring that the storage space is
+        reclaimed.
 
         Args:
-            snapshot_id (str): _description_
+            snapshot_id (str): ID of the snapshot to be removed.
 
         Returns:
-            Dict[str, Union[str, int]]: _description_
+            Dict[str, Union[str, int]]: A dictionary containing a message with
+                the results of the deletion operation.
+
+        Raises:
+            ResticRestoreError: If the snapshot deletion operation fails.
         """
         result = self.executor.execute(
             f'{self.FORGET_SUBCOMMAND} {snapshot_id}'

--- a/openvair/modules/backup/domain/backupers/restic_backuper.py
+++ b/openvair/modules/backup/domain/backupers/restic_backuper.py
@@ -167,3 +167,19 @@ class ResticBackuper(FSBackuper):
             message = f'Error while getting snapshots: {err!s}'
             LOG.error(message)
             raise SnapshotGettingResticBackuperError(message)
+
+    def delete_snapshot(
+        self, data: Dict[str, str]
+    ) -> Dict[str, Union[str, int, None]]:
+        """_summary_
+
+        Args:
+            data (Dict[str, str]): _description_
+
+        Raises:
+            NotImplementedError: _description_
+
+        Returns:
+            Dict[str, Union[str, int, None]]: _description_
+        """
+        raise NotImplementedError

--- a/openvair/modules/backup/domain/backupers/restic_backuper.py
+++ b/openvair/modules/backup/domain/backupers/restic_backuper.py
@@ -172,16 +172,21 @@ class ResticBackuper(FSBackuper):
     def delete_snapshot(
         self, data: Dict[str, str]
     ) -> Dict[str, Union[str, int, None]]:
-        """_summary_
+        """Delete a specific snapshot from the Restic repository.
+
+        This method removes a snapshot from the Restic repository using
+        the `forget --prune` command.
 
         Args:
-            data (Dict[str, str]): _description_
-
-        Raises:
-            NotImplementedError: _description_
+            data (Dict[str, str]): Dictionary containing snapshot information.
+                Must include the key `snapshot_id`.
 
         Returns:
-            Dict[str, Union[str, int, None]]: _description_
+            Dict[str, Union[str, int, None]]: Information about the deletion
+                result, corresponding to the `ResticDeleteResult` model.
+
+        Raises:
+            RestoreResticBackuperError: If the deletion operation fails.
         """
         snapshot_id = data['snapshot_id']
         try:

--- a/openvair/modules/backup/domain/base.py
+++ b/openvair/modules/backup/domain/base.py
@@ -76,7 +76,7 @@ class FSBackuper(BaseBackuper):
     def delete_snapshot(
         self, data: Dict[str, str]
     ) -> Dict[str, Union[str, int, None]]:
-        """Delete a specific backup snapshot.
+        """Delete a specific snapshot.
 
         This abstract method should be implemented by subclasses to remove
         a snapshot from the backup repository.

--- a/openvair/modules/backup/domain/base.py
+++ b/openvair/modules/backup/domain/base.py
@@ -71,3 +71,22 @@ class FSBackuper(BaseBackuper):
                 represented as a dictionary.
         """
         ...
+
+    @abstractmethod
+    def delete_snapshot(
+        self, data: Dict[str, str]
+    ) -> Dict[str, Union[str, int, None]]:
+        """Delete a specific backup snapshot.
+
+        This abstract method should be implemented by subclasses to remove
+        a snapshot from the backup repository.
+
+        Args:
+            data (Dict[str, str]): A dictionary containing the snapshot ID
+                to be deleted.
+
+        Returns:
+            Dict[str, Union[str, int, None]]: A dictionary containing the result
+                of the deletion operation.
+        """
+        ...

--- a/openvair/modules/backup/entrypoints/api.py
+++ b/openvair/modules/backup/entrypoints/api.py
@@ -164,17 +164,18 @@ async def delete_backup(
 ) -> BaseResponse[ResticDeleteResult]:
     """Delete a specific backup snapshot.
 
-    This endpoint removes a backup snapshot by calling the `BackupCrud` service.
+    This endpoint removes a backup snapshot by calling the `BackupCrud`.
 
     Args:
         snapshot_id (str): ID of the snapshot to delete.
-        crud (BackupCrud): Dependency injection of the `BackupCrud` service.
+        crud (BackupCrud): Dependency injection of the `BackupCrud`.
 
     Dependencies:
         - User authentication via `get_current_user`.
 
     Returns:
-        BaseResponse: A response indicating the success of the operation.
+        BaseResponse[ResticDeleteResult]: A response containing the result
+            of the deletion operation.
     """
     LOG.info(f'API: Start deleting snapshot: {snapshot_id}')
     result = await run_in_threadpool(crud.delete_snapshot, snapshot_id)

--- a/openvair/modules/backup/entrypoints/crud.py
+++ b/openvair/modules/backup/entrypoints/crud.py
@@ -109,13 +109,14 @@ class BackupCrud:
     def delete_snapshot(self, snapshot_id: str) -> ResticDeleteResult:
         """Delete a specific backup snapshot.
 
-        This method calls the service layer to remove a given backup snapshot.
+        This method calls the service layer to remove a snapshot from the
+        backup repository.
 
         Args:
             snapshot_id (str): ID of the snapshot to delete.
 
         Returns:
-            None
+            ResticDeleteResult: The result of the deletion operation.
         """
         delete_info = self.service_layer_rpc.call(
             BackupServiceLayerManager.delete_snapshot.__name__,

--- a/openvair/modules/backup/entrypoints/crud.py
+++ b/openvair/modules/backup/entrypoints/crud.py
@@ -104,3 +104,19 @@ class BackupCrud:
         self.service_layer_rpc.call(
             BackupServiceLayerManager.initialize_backup_repository.__name__
         )
+
+    def delete_snapshot(self, snapshot_id: str) -> None:
+        """Delete a specific backup snapshot.
+
+        This method calls the service layer to remove a given backup snapshot.
+
+        Args:
+            snapshot_id (str): ID of the snapshot to delete.
+
+        Returns:
+            None
+        """
+        self.service_layer_rpc.call(
+            BackupServiceLayerManager.delete_snapshot.__name__,
+            data_for_method={'snapshot_id': snapshot_id},
+        )

--- a/openvair/modules/backup/entrypoints/crud.py
+++ b/openvair/modules/backup/entrypoints/crud.py
@@ -16,6 +16,7 @@ from openvair.modules.backup.config import API_SERVICE_LAYER_QUEUE_NAME
 from openvair.modules.backup.schemas import (
     ResticSnapshot,
     ResticBackupResult,
+    ResticDeleteResult,
     ResticRestoreResult,
 )
 from openvair.libs.messaging.messaging_agents import MessagingClient
@@ -105,7 +106,7 @@ class BackupCrud:
             BackupServiceLayerManager.initialize_backup_repository.__name__
         )
 
-    def delete_snapshot(self, snapshot_id: str) -> None:
+    def delete_snapshot(self, snapshot_id: str) -> ResticDeleteResult:
         """Delete a specific backup snapshot.
 
         This method calls the service layer to remove a given backup snapshot.
@@ -116,7 +117,8 @@ class BackupCrud:
         Returns:
             None
         """
-        self.service_layer_rpc.call(
+        delete_info = self.service_layer_rpc.call(
             BackupServiceLayerManager.delete_snapshot.__name__,
             data_for_method={'snapshot_id': snapshot_id},
         )
+        return ResticDeleteResult(**delete_info)

--- a/openvair/modules/backup/schemas.py
+++ b/openvair/modules/backup/schemas.py
@@ -120,13 +120,20 @@ class ResticSnapshot(BaseModel):
 
         extra = 'ignore'
 
-class ResticDeleteResult(BaseModel):
-    """_summary_
 
-    Args:
-        BaseModel (_type_): _description_
+class ResticDeleteResult(BaseModel):
+    """Schema for restic snapshot deletion results.
+
+    This schema represents the result of a snapshot deletion operation
+    performed using Restic.
+
+    Attributes:
+        message (str): A message describing the outcome of the deletion
+            operation, including stdout and stderr details.
     """
+
     message: str
+
 
 class ResticBackuperData(BaseModel):
     """Schema for Restic backuper configuration data.

--- a/openvair/modules/backup/schemas.py
+++ b/openvair/modules/backup/schemas.py
@@ -120,6 +120,13 @@ class ResticSnapshot(BaseModel):
 
         extra = 'ignore'
 
+class ResticDeleteResult(BaseModel):
+    """_summary_
+
+    Args:
+        BaseModel (_type_): _description_
+    """
+    message: str
 
 class ResticBackuperData(BaseModel):
     """Schema for Restic backuper configuration data.

--- a/openvair/modules/backup/service_layer/services.py
+++ b/openvair/modules/backup/service_layer/services.py
@@ -86,6 +86,27 @@ class BackupServiceLayerManager(BackgroundTasks):
         LOG.info('Backup successfull created')
         return result
 
+    def delete_snapshot(
+        self, data: Dict[str, str]
+    ) -> Dict[str, Union[str, int, None]]:
+        """_summary_
+
+        Args:
+            data (Dict[str, str]): _description_
+
+        Raises:
+            NotImplementedError: _description_
+
+        Returns:
+            Dict[str, Union[str, int, None]]: _description_
+        """
+        self.domain_rpc.call(
+            FSBackuper.delete_snapshot.__name__,
+            data_for_manager=self.__create_data_for_domain_manager(),
+            data_for_method={'snapshot_id': data.get('snapshot_id', 'latest')},
+        )
+        raise NotImplementedError
+
     def restore_backup(
         self,
         data: Dict[

--- a/openvair/modules/backup/service_layer/services.py
+++ b/openvair/modules/backup/service_layer/services.py
@@ -89,16 +89,18 @@ class BackupServiceLayerManager(BackgroundTasks):
     def delete_snapshot(
         self, data: Dict[str, str]
     ) -> Dict[str, Union[str, int, None]]:
-        """_summary_
+        """Delete a specific snapshot.
+
+        This method invokes the domain layer to remove a snapshot from the
+        backup repository.
 
         Args:
-            data (Dict[str, str]): _description_
-
-        Raises:
-            NotImplementedError: _description_
+            data (Dict[str, str]): Dictionary containing snapshot information.
+                Must include the key `snapshot_id`.
 
         Returns:
-            Dict[str, Union[str, int, None]]: _description_
+            Dict[str, Union[str, int, None]]: Information about the deletion
+                result.
         """
         result: Dict[str, Union[str, int, None]] = self.domain_rpc.call(
             FSBackuper.delete_snapshot.__name__,

--- a/openvair/modules/backup/service_layer/services.py
+++ b/openvair/modules/backup/service_layer/services.py
@@ -100,12 +100,12 @@ class BackupServiceLayerManager(BackgroundTasks):
         Returns:
             Dict[str, Union[str, int, None]]: _description_
         """
-        self.domain_rpc.call(
+        result: Dict[str, Union[str, int, None]] = self.domain_rpc.call(
             FSBackuper.delete_snapshot.__name__,
             data_for_manager=self.__create_data_for_domain_manager(),
-            data_for_method={'snapshot_id': data.get('snapshot_id', 'latest')},
+            data_for_method={'snapshot_id': data.get('snapshot_id')},
         )
-        raise NotImplementedError
+        return result
 
     def restore_backup(
         self,


### PR DESCRIPTION
# **Описание выполненных изменений**

В рамках задачи **#103 "Добавить функционал удаления бэкапа"** был реализован функционал для удаления ранее созданных бэкапов в модуле `openvair/modules/backup`.

---

# **Основные изменения**

1. **Adapters (adapters/restic/restic.py):**
   - Добавлен метод `forget`, который использует команду `forget --prune` для удаления снапшота из репозитория Restic.
   - Метод возвращает информацию о результате удаления (stdout и stderr).
   - Обновлена проверка результата выполнения команд (`_check_result`).

2. **Domain Layer (domain/backupers/restic_backuper.py):**
   - Добавлен метод `delete_snapshot`, реализующий бизнес-логику удаления снапшота.
   - Логирование процесса удаления с указанием успешных и неуспешных операций.

3. **Service Layer (service_layer/services.py):**
   - Добавлен метод `delete_snapshot`, который вызывает доменный слой для выполнения операции удаления.
   - Реализована обработка данных для передачи в доменный слой.

4. **CRUD (entrypoints/crud.py):**
   - Добавлен метод `delete_snapshot`, который взаимодействует с сервисным слоем для выполнения удаления.
   - Возвращается результат в формате `ResticDeleteResult`.

5. **Entrypoints (entrypoints/api.py):**
   - Реализован новый эндпоинт для удаления бэкапа:
     ```python
     @router.delete(
         '/{snapshot_id}',
         dependencies=[Depends(get_current_user)],
         response_model=BaseResponse[ResticDeleteResult],
     )
     async def delete_backup(
         snapshot_id: str,
         crud: BackupCrud = Depends(BackupCrud),
     ) -> BaseResponse[ResticDeleteResult]:
         """Delete a specific backup snapshot."""
         result = await run_in_threadpool(crud.delete_snapshot, snapshot_id)
         return BaseResponse(status='success', data=result)
     ```
   - Эндпоинт требует аутентификацию через `get_current_user`.

6. **Schemas (schemas.py):**
   - Добавлена новая схема `ResticDeleteResult`, описывающая структуру данных для результата удаления снапшота.

---

# **Результаты реализации**

- Удаление бэкапа осуществляется по `snapshot_id`.
- Корректно обрабатываются случаи, когда указанный бэкап не найден.
- Эндпоинт требует обязательной аутентификации пользователя.
- Логика удаления распределена по слоям модуля в соответствии с архитектурой проекта.
