### PR TITLE
Миграция модуля volume на новую версию execute

### DIFF
--- a/openvair/modules/volume/domain/physical_fs/localfs.py
+++ b/openvair/modules/volume/domain/physical_fs/localfs.py
@@ -9,9 +9,12 @@ Classes:
 """
 
 from typing import Any, Dict
+from pathlib import Path
 
 from openvair.libs.log import get_logger
-from openvair.modules.tools.utils import execute
+from openvair.libs.cli.models import ExecuteParams
+from openvair.libs.cli.executor import execute
+from openvair.libs.cli.exceptions import ExecuteError
 from openvair.modules.volume.domain.base import BaseVolume
 
 LOG = get_logger(__name__)
@@ -88,18 +91,27 @@ class LocalFSVolume(BaseLocalFSVolume):
             f'size={self.size}, format={self.format}'
         )
         preallocation = self.provisioning if self.format != 'raw' else 'off'
-        volume_path = f'{self.path}/volume-{self.id}'
-        execute(
-            'qemu-img',
-            'create',
-            '-f',
-            self.format,
-            '-o',
-            f'preallocation={preallocation}',
-            volume_path,
-            self.size,
-            run_as_root=self._execute_as_root,
-        )
+        volume_path = Path(self.path, f'volume-{self.id}')
+        try:
+            execute(
+                'qemu-img',
+                'create',
+                '-f',
+                self.format,
+                '-o',
+                f'preallocation={preallocation}',
+                str(volume_path),
+                self.size,
+                params=ExecuteParams(  # noqa: S604
+                    run_as_root=self._execute_as_root,
+                    shell=True,
+                    raise_on_error=True,
+                )
+            )
+        except (ExecuteError, OSError) as err:
+            LOG.error(f'Error while creating volume: {err!s}')
+            raise
+
         return self.__dict__
 
     def delete(self) -> Dict:
@@ -109,8 +121,22 @@ class LocalFSVolume(BaseLocalFSVolume):
             Dict: A dictionary representation of the volume's attributes.
         """
         LOG.info(f'Deleting volume with id={self.id}, path={self.path}')
-        volume_path = f'{self.path}/volume-{self.id}'
-        execute('rm', '-f', volume_path, run_as_root=self._execute_as_root)
+        volume_path = Path(self.path, f'volume-{self.id}')
+        try:
+            execute(
+                'rm',
+                '-f',
+                str(volume_path),
+                params=ExecuteParams(  # noqa: S604
+                    run_as_root=self._execute_as_root,
+                    shell=True,
+                    raise_on_error=True,
+                )
+            )
+        except (ExecuteError, OSError) as err:
+            LOG.error(f'Error while deleting volume: {err!s}')
+            raise
+
         return self.__dict__
 
     def extend(self, new_size: str) -> Dict:
@@ -127,14 +153,23 @@ class LocalFSVolume(BaseLocalFSVolume):
             f'path={self.path} to new size={new_size}'
         )
         self._check_volume_exists()
-        volume_path = f'{self.path}/volume-{self.id}'
-        execute(
-            'qemu-img',
-            'resize',
-            volume_path,
-            new_size,
-            run_as_root=self._execute_as_root,
-        )
+        volume_path = Path(self.path, f'volume-{self.id}')
+        try:
+            execute(
+                'qemu-img',
+                'resize',
+                str(volume_path),
+                new_size,
+                params=ExecuteParams(  # noqa: S604
+                    run_as_root=self._execute_as_root,
+                    shell=True,
+                    raise_on_error=True,
+                )
+            )
+        except (ExecuteError, OSError) as err:
+            LOG.error(f'Error while extending volume: {err!s}')
+            raise
+
         return self.__dict__
 
     def attach_volume_info(self) -> Dict:

--- a/openvair/modules/volume/domain/physical_fs/localfs.py
+++ b/openvair/modules/volume/domain/physical_fs/localfs.py
@@ -101,7 +101,7 @@ class LocalFSVolume(BaseLocalFSVolume):
                 '-o',
                 f'preallocation={preallocation}',
                 str(volume_path),
-                self.size,
+                str(self.size),
                 params=ExecuteParams(  # noqa: S604
                     run_as_root=self._execute_as_root,
                     shell=True,
@@ -159,7 +159,7 @@ class LocalFSVolume(BaseLocalFSVolume):
                 'qemu-img',
                 'resize',
                 str(volume_path),
-                new_size,
+                str(new_size),
                 params=ExecuteParams(  # noqa: S604
                     run_as_root=self._execute_as_root,
                     shell=True,

--- a/openvair/modules/volume/domain/remotefs/nfs.py
+++ b/openvair/modules/volume/domain/remotefs/nfs.py
@@ -60,7 +60,7 @@ class NfsVolume(RemoteFSVolume):
                 '-o',
                 f'preallocation={preallocation}',
                 str(volume_path),
-                self.size,
+                str(self.size),
                 params=ExecuteParams(  # noqa: S604
                     run_as_root=self._execute_as_root,
                     shell=True,
@@ -125,8 +125,11 @@ class NfsVolume(RemoteFSVolume):
                 'qemu-img',
                 'resize',
                 str(volume_path),
-                new_size,
-                run_as_root=self._execute_as_root,
+                str(new_size),
+                params=ExecuteParams(  # noqa: S604
+                    shell=True,
+                    run_as_root=self._execute_as_root,
+                )
             )
         except (ExecuteError, OSError) as err:
             message = f'Qemu img extend volume raised exception: {err!s}'

--- a/openvair/modules/volume/domain/remotefs/nfs.py
+++ b/openvair/modules/volume/domain/remotefs/nfs.py
@@ -8,9 +8,12 @@ Classes:
 """
 
 from typing import Any, Dict
+from pathlib import Path
 
 from openvair.libs.log import get_logger
-from openvair.modules.tools.utils import execute
+from openvair.libs.cli.models import ExecuteParams
+from openvair.libs.cli.executor import execute
+from openvair.libs.cli.exceptions import ExecuteError
 from openvair.modules.volume.domain.base import RemoteFSVolume
 from openvair.modules.volume.domain.remotefs import exceptions
 
@@ -47,22 +50,28 @@ class NfsVolume(RemoteFSVolume):
             Dict: A dictionary representation of the volume's attributes.
         """
         preallocation = self.provisioning if self.format != 'raw' else 'off'
-        volume_path = f'{self.path}/volume-{self.id}'
-        _, err = execute(
-            'qemu-img',
-            'create',
-            '-f',
-            self.format,
-            '-o',
-            f'preallocation={preallocation}',
-            volume_path,
-            self.size,
-            run_as_root=self._execute_as_root,
-        )
-        if err:
+        volume_path = Path(self.path, f'volume-{self.id}')
+        try:
+            execute(
+                'qemu-img',
+                'create',
+                '-f',
+                self.format,
+                '-o',
+                f'preallocation={preallocation}',
+                str(volume_path),
+                self.size,
+                params=ExecuteParams(  # noqa: S604
+                    run_as_root=self._execute_as_root,
+                    shell=True,
+                    raise_on_error=True,
+                )
+            )
+        except (ExecuteError, OSError) as err:
             message = f'Qemu img create raised exception: {err!s}'
             LOG.error(message)
             raise exceptions.QemuImgCreateException(message)
+
         LOG.info(f'Created volume {volume_path}')
         return self.__dict__
 
@@ -76,17 +85,23 @@ class NfsVolume(RemoteFSVolume):
         Returns:
             Dict: A dictionary representation of the volume's attributes.
         """
-        volume_path = f'{self.path}/volume-{self.id}'
-        _, err = execute(
-            'rm',
-            '-f',
-            volume_path,
-            run_as_root=self._execute_as_root,
-        )
-        if err:
+        volume_path = Path(self.path, f'volume-{self.id}')
+        try:
+            execute(
+                'rm',
+                '-f',
+                str(volume_path),
+                params=ExecuteParams(  # noqa: S604
+                    run_as_root=self._execute_as_root,
+                    shell=True,
+                    raise_on_error=True,
+                )
+            )
+        except (ExecuteError, OSError) as err:
             message = f'Delete volume raised exception: {err!s}'
             LOG.error(message)
             raise exceptions.DeleteVolumeException(message)
+
         LOG.info(f'Deleted volume {volume_path}')
         return self.__dict__
 
@@ -104,18 +119,20 @@ class NfsVolume(RemoteFSVolume):
             Dict: A dictionary representation of the volume's attributes.
         """
         self._check_volume_exists()
-        volume_path = f'{self.path}/volume-{self.id}'
-        _, err = execute(
-            'qemu-img',
-            'resize',
-            volume_path,
-            new_size,
-            run_as_root=self._execute_as_root,
-        )
-        if err:
+        volume_path = Path(self.path, f'volume-{self.id}')
+        try:
+            execute(
+                'qemu-img',
+                'resize',
+                str(volume_path),
+                new_size,
+                run_as_root=self._execute_as_root,
+            )
+        except (ExecuteError, OSError) as err:
             message = f'Qemu img extend volume raised exception: {err!s}'
             LOG.error(message)
             raise exceptions.QemuImgExtendException(message)
+
         LOG.info(f'Extended volume {volume_path} to size {new_size}')
         return self.__dict__
 


### PR DESCRIPTION
# Описание изменений

Произведена миграция модуля `volume` на новую версию функции `execute`. Изменения направлены на улучшение обработки ошибок, повышение читаемости кода и использование новых параметров вызова `execute`.

---

# Основные изменения

- Заменён импорт `execute` с `openvair.modules.tools.utils` на `openvair.libs.cli.executor.execute`.
- Добавлены новые модели `ExecuteParams`, `ExecutionResult` и исключение `ExecuteError` из `openvair.libs.cli`.
- Изменён вызов `execute` в методах:
  - `BaseVolume.get_volume_info()`
  - `LocalFSVolume.create()`
  - `LocalFSVolume.delete()`
  - `LocalFSVolume.extend()`
  - `NfsVolume.create()`
  - `NfsVolume.delete()`
  - `NfsVolume.extend()`
  
- Улучшена обработка ошибок:
  - Используются `try-except` блоки для отлова `ExecuteError` и `OSError`.
  - Ошибки логируются с дополнительной информацией (`LOG.error`).
  - Исключения пробрасываются выше при критических ошибках (`raise`).
- Путь к файлу `volume` теперь создаётся через `Path` из `pathlib` для повышения переносимости кода.
- Аргументы `execute` теперь передаются через `ExecuteParams`, включая `shell=True`, `raise_on_error=True`, `timeout` и `run_as_root`.

---

# Требования к тестированию

1. **Проверка `get_volume_info()`**
   - Вызвать метод `BaseVolume.get_volume_info()`, убедиться, что JSON-ответ корректно парсится.
   - Проверить обработку ошибки при некорректном выводе `qemu-img info`.
   
2. **Создание тома (`create()`)**
   - Проверить создание тома в `LocalFSVolume` и `NfsVolume`.
   - В случае ошибки убедиться, что корректно логируется сообщение и выбрасывается исключение.

3. **Удаление тома (`delete()`)**
   - Проверить удаление тома.
   - При отсутствии файла убедиться, что ошибка корректно логируется.

4. **Расширение тома (`extend()`)**
   - Проверить корректное изменение размера тома.
   - Проверить обработку ошибок в случае невозможности изменения размера.

---

# Критерии приёмки

- Код успешно проходит все тесты.
- Ошибки корректно логируются и обрабатываются.
- Новая версия `execute` используется во всех затронутых методах.

---

# Заключение

Данный PR улучшает обработку командной строки и снижает риск пропуска критических ошибок. Улучшена читаемость и поддерживаемость кода.
