### PR TITLE
Миграция модуля network на новую версию execute

### DIFF
--- a/openvair/modules/network/domain/interfaces/physical.py
+++ b/openvair/modules/network/domain/interfaces/physical.py
@@ -11,7 +11,8 @@ Classes:
 from typing import Any
 
 from openvair.libs.log import get_logger
-from openvair.modules.tools.utils import execute
+from openvair.libs.cli.models import ExecuteParams
+from openvair.libs.cli.executor import execute
 from openvair.modules.network.domain.base import BaseInterface
 
 LOG = get_logger(__name__)
@@ -45,7 +46,14 @@ class PhysicalInterface(BaseInterface):
         """
         LOG.info(f'Domain layer start enabling physical interface {self.name}')
         # It may not enable on the first attempt.
-        execute('ip', 'link', 'set', self.name, 'up', run_as_root=True)
+        execute(
+            f'ip link set {self.name} up',
+            params=ExecuteParams(  # noqa: S604
+                shell=True,
+                run_as_root=True,
+                raise_on_error=True,
+            ),
+        )
         LOG.info(
             f'Domain layer successfully enabled physical interface {self.name}'
         )
@@ -58,7 +66,14 @@ class PhysicalInterface(BaseInterface):
         """
         LOG.info(f'Domain layer start disabling physical interface {self.name}')
         # It may not disable on the first attempt.
-        execute('ip', 'link', 'set', self.name, 'down', run_as_root=True)
+        execute(
+            f'ip link set {self.name} down',
+            params=ExecuteParams(  # noqa: S604
+                shell=True,
+                run_as_root=True,
+                raise_on_error=True,
+            ),
+        )
         LOG.info(
             f'Domain layer successfully disabled physical interface {self.name}'
         )

--- a/openvair/modules/network/domain/interfaces/virtual.py
+++ b/openvair/modules/network/domain/interfaces/virtual.py
@@ -48,7 +48,7 @@ class VirtualInterface(BaseInterface):
             ),
         )
         LOG.info(
-            f'Domain layer successfully enabled physical interface {self.name}'
+            f'Domain layer successfully enabled virtual interface {self.name}'
         )
 
     def disable(self) -> None:

--- a/openvair/modules/network/domain/interfaces/virtual.py
+++ b/openvair/modules/network/domain/interfaces/virtual.py
@@ -11,7 +11,8 @@ Classes:
 from typing import Any
 
 from openvair.libs.log import get_logger
-from openvair.modules.tools.utils import execute
+from openvair.libs.cli.models import ExecuteParams
+from openvair.libs.cli.executor import execute
 from openvair.modules.network.domain.base import BaseInterface
 
 LOG = get_logger(__name__)
@@ -38,9 +39,16 @@ class VirtualInterface(BaseInterface):
         """
         LOG.info(f'Domain layer start enabling virtual interface {self.name}')
         # It may not enable on the first attempt.
-        execute('ip', 'link', 'set', self.name, 'up', run_as_root=True)
+        execute(
+            f'ip link set {self.name} up',
+            params=ExecuteParams(  # noqa: S604
+                shell=True,
+                run_as_root=True,
+                raise_on_error=True,
+            ),
+        )
         LOG.info(
-            f'Domain layer successfully enabled virtual interface {self.name}'
+            f'Domain layer successfully enabled physical interface {self.name}'
         )
 
     def disable(self) -> None:
@@ -50,7 +58,14 @@ class VirtualInterface(BaseInterface):
         """
         LOG.info(f'Domain layer start disabling virtual interface {self.name}')
         # It may not disable on the first attempt.
-        execute('ip', 'link', 'set', self.name, 'down', run_as_root=True)
+        execute(
+            f'ip link set {self.name} down',
+            params=ExecuteParams(  # noqa: S604
+                shell=True,
+                run_as_root=True,
+                raise_on_error=True,
+            ),
+        )
         LOG.info(
             f'Domain layer successfully disabled virtual interface {self.name}'
         )

--- a/openvair/modules/network/domain/utils/ip_manager.py
+++ b/openvair/modules/network/domain/utils/ip_manager.py
@@ -12,7 +12,8 @@ import json
 from typing import Any, Dict, List, Tuple
 
 from openvair.libs.log import get_logger
-from openvair.modules.tools.utils import execute
+from openvair.libs.cli.models import ExecuteParams
+from openvair.libs.cli.executor import execute
 from openvair.modules.network.domain.utils.exceptions import (
     IPManagerException,
     InvalidAddressException,
@@ -28,32 +29,47 @@ class IPManager:
     """
 
     def _get_addresses_data(self) -> Dict[str, Dict[str, Any]]:
-        cmd = 'sudo ip -j a'
-        result, error = execute(cmd)
-        if error:
-            message = f'Failure while getting addresses info: {error}'
+        command = 'ip -j a'
+        exec_res = execute(
+            command,
+            params=ExecuteParams(  # noqa: S604
+                run_as_root=True,
+                shell=True,
+            ),
+        )
+        if exec_res.stderr:
+            message = f'Failure while getting addresses info: {exec_res.stderr}'
             LOG.error(message)
             raise IPManagerException(message)
-        addresses: List[Dict] = json.loads(result)
+        addresses: List[Dict] = json.loads(exec_res.stdout)
         return {iface['ifname']: iface for iface in addresses}
 
     def _get_interfaces_data(self) -> Dict[str, Dict[str, Any]]:
-        cmd = 'sudo ip -j link show'
-        result, error = execute(cmd)
-        if error:
-            message = f'Failure while gettin interfaces info: {error}'
+        command = 'ip -j link show'
+        exec_res = execute(
+            command,
+            params=ExecuteParams(  # noqa: S604
+                run_as_root=True,
+                shell=True,
+            ),
+        )
+        if exec_res.stderr:
+            message = f'Failure while gettin interfaces info: {exec_res.stderr}'
             LOG.error(message)
             raise IPManagerException(message)
-        interfaces: List[Dict] = json.loads(result)
+        interfaces: List[Dict] = json.loads(exec_res.stdout)
         return {iface['ifname']: iface for iface in interfaces}
 
     def _get_routes_data(self) -> List[Dict]:
-        cmd = 'ip -j route'
-        result, error = execute(cmd)
-        if error:
-            msg = f'Failure while getting main port name: {error}'
+        command = 'ip -j route'
+        exec_res = execute(
+            command,
+            params=ExecuteParams(shell=True)  # noqa: S604
+        )
+        if exec_res.stderr:
+            msg = f'Failure while getting main port name: {exec_res.stderr}'
             raise IPManagerException(msg)
-        routes_info: List[Dict] = json.loads(result)
+        routes_info: List[Dict] = json.loads(exec_res.stdout)
         return routes_info
 
     def get_iface_data(self, iface_name: str) -> Dict:
@@ -105,25 +121,40 @@ class IPManager:
         """
         LOG.info(f'Setting IP: {ip_address} to the: {iface_name}')
 
-        command = f'sudo ip addr add {ip_address} dev {iface_name}'
-        result, error = execute(command)
-        if error:
+        command = f'ip addr add {ip_address} dev {iface_name}'
+        exec_res = execute(
+            command,
+            params=ExecuteParams(  # noqa: S604
+                run_as_root=True,
+                shell=True,
+            ),
+        )
+        if exec_res.stderr:
             message = (
                 f'Error setting IP address {ip_address} '
-                f'for interface {iface_name}: {error}'
+                f'for interface {iface_name}: {exec_res.stderr}'
             )
             raise InvalidAddressException(message)
-        LOG.info(result)
-        LOG.info(error)
+        LOG.info(exec_res.stdout)
+        LOG.info(exec_res.stderr)
         LOG.info('IP address was successfully set')
-        return result.strip()
+        return exec_res.stdout.strip()
 
     def set_alias(self, iface_name: str, alias: str) -> None:
         """Sertting alias for interface"""
-        command = f'sudo ip link set {iface_name} alias "{alias}"'
-        _, error = execute(command)
-        if error:
-            message = f'Error setting alias for interface {iface_name}: {error}'
+        command = f'ip link set {iface_name} alias "{alias}"'
+        exec_res = execute(
+            command,
+            params=ExecuteParams(  # noqa: S604
+                run_as_root=True,
+                shell=True,
+            ),
+        )
+        if exec_res.stdout:
+            message = (
+                f'Error setting alias for interface {iface_name}: '
+                f'{exec_res.stderr}'
+            )
             err = IPManagerException(message)
             LOG.error(err)
             raise err
@@ -142,15 +173,21 @@ class IPManager:
         Raises:
             InvalidAddressException: If removing the IP address fails.
         """
-        command = f'sudo ip addr del {ip_address} dev {iface_name}'
-        result, error = execute(command)
-        if error:
+        command = f'ip addr del {ip_address} dev {iface_name}'
+        exec_res = execute(
+            command,
+            params=ExecuteParams(  # noqa: S604
+                run_as_root=True,
+                shell=True,
+            ),
+        )
+        if exec_res.stderr:
             message = (
                 f'Error removing IP address {ip_address} from interface '
-                f'{iface_name}: {error}'
+                f'{iface_name}: {exec_res.stderr}'
             )
             raise InvalidAddressException(message)
-        return result.strip()
+        return exec_res.stdout.strip()
 
     @staticmethod
     def turn_on_interface(iface_name: str) -> str:
@@ -166,15 +203,22 @@ class IPManager:
             IPManagerException: If turning on the interface fails.
         """
         LOG.info('Turning the bridge on')
-        command = f'sudo ip link set {iface_name} up'
-        result, error = execute(command)
-
-        if error:
-            message = f'Error turning on interface {iface_name}: {error}'
+        command = f'ip link set {iface_name} up'
+        exec_res = execute(
+            command,
+            params=ExecuteParams(  # noqa: S604
+                run_as_root=True,
+                shell=True,
+            ),
+        )
+        if exec_res.stderr:
+            message = (
+                f'Error turning on interface {iface_name}: {exec_res.stderr}'
+            )
             raise IPManagerException(message)
         LOG.info(f"The bridge '{iface_name}' was successfully created")
 
-        return result.strip()
+        return exec_res.stdout.strip()
 
     @staticmethod
     def turn_off_interface(iface_name: str) -> str:
@@ -189,16 +233,24 @@ class IPManager:
         Raises:
             IPManagerException: If turning off the interface fails.
         """
-        command = f'sudo ip link set {iface_name} down'
-        result, error = execute(command)
-        if error:
-            message = f'Error turning off interface {iface_name}: {error}'
+        command = f'ip link set {iface_name} down'
+        exec_res = execute(
+            command,
+            params=ExecuteParams(  # noqa: S604
+                run_as_root=True,
+                shell=True,
+            ),
+        )
+        if exec_res.stderr:
+            message = (
+                f'Error turning off interface {iface_name}: {exec_res.stderr}'
+            )
             raise IPManagerException(message)
-        return result.strip()
+        return exec_res.stdout.strip()
 
     @staticmethod
     def check_interface_state(
-        iface_name: str, expected_states: tuple = ('UP', 'DOWN')
+        iface_name: str, expected_states: tuple = ('UP', 'DOWN', 'UNKNOW')
     ) -> bool:
         """Check the state of the given interface.
 
@@ -210,12 +262,23 @@ class IPManager:
             bool: True if the interface has any of the expected states,
                 False otherwise.
         """
-        command = f'sudo ip link show {iface_name}'
-        result, error = execute(command)
-        if error:
-            message = f'Error occurred while checking interface state: {error}'
+        command = f'ip link show {iface_name}'
+        exec_res = execute(
+            command,
+            params=ExecuteParams(  # noqa: S604
+                run_as_root=True,
+                shell=True,
+            ),
+        )
+        if exec_res.stderr:
+            message = (
+                'Error occurred while checking interface state: '
+                f'{exec_res.stderr}'
+            )
             raise IPManagerException(message)
-        return any(f'state {state}' in result for state in expected_states)
+        return any(
+            f'state {state}' in exec_res.stdout for state in expected_states
+        )
 
     @staticmethod
     def get_interface_addresses(iface_name: str) -> List[str]:
@@ -231,19 +294,24 @@ class IPManager:
             NetworkInterfaceException: If retrieving the IP addresses fails.
         """
         command = (
-            f'sudo ip addr show {iface_name} | '
-            f"grep 'inet ' | awk '{{print $2}}'"
+            f'ip addr show {iface_name} | ' f"grep 'inet ' | awk '{{print $2}}'"
         )
-        result, error = execute(command)
+        exec_res = execute(
+            command,
+            params=ExecuteParams(  # noqa: S604
+                run_as_root=True,
+                shell=True,
+            ),
+        )
 
-        if error:
+        if exec_res.stderr:
             message = (
                 f"Error occurred while getting interface '{iface_name}'"
-                f' IP addresses: {error}'
+                f' IP addresses: {exec_res.stderr}'
             )
             raise IPManagerException(message)
 
-        return result.strip().split('\n')
+        return exec_res.stdout.strip().split('\n')
 
     # need replce by get_addresses
     @staticmethod
@@ -260,20 +328,26 @@ class IPManager:
             NetworkInterfaceException: If retrieving the IP address fails.
         """
         command = (
-            f'sudo ip addr show {port_name} |'
+            f'ip addr show {port_name} |'
             " awk '/inet / {print $2}' | cut -d '/' -f 1"
         )
-        result, error = execute(command)
+        exec_res = execute(
+            command,
+            params=ExecuteParams(  # noqa: S604
+                run_as_root=True,
+                shell=True,
+            ),
+        )
 
-        if error:
-            message = f'Failure while getting main port IP: {error}'
+        if exec_res.stderr:
+            message = f'Failure while getting main port IP: {exec_res.stderr}'
             raise IPManagerException(message)
 
-        if not result.strip():
+        if not exec_res.stdout.strip():
             LOG.info('Got an empty result while getting main port IP')
             return ''
 
-        return result.strip().split()[0]
+        return exec_res.stdout.strip().split()[0]
 
     @staticmethod
     def flush_iface_ip(iface_name: str) -> str:
@@ -289,14 +363,20 @@ class IPManager:
             NetworkInterfaceException: If flushing the IP addresses fails.
         """
         LOG.info(f'Flushing IP from: {iface_name}...')
-        command = f'sudo ip addr flush dev {iface_name}'
-        result, error = execute(command)
+        command = f' ip addr flush dev {iface_name}'
+        exec_res = execute(
+            command,
+            params=ExecuteParams(  # noqa: S604
+                run_as_root=True,
+                shell=True,
+            ),
+        )
 
-        if error:
-            message = f'Failure while removing IP from port: {error}'
+        if exec_res.stderr:
+            message = f'Failure while removing IP from port: {exec_res.stderr}'
             raise IPManagerException(message)
 
-        return result.strip()
+        return exec_res.stdout.strip()
 
     def is_dhcp_ip(self, iface_name: str) -> bool:
         """Check if dhcp enabled for interface"""
@@ -320,9 +400,15 @@ class IPManager:
         Returns:
             str: Command stdout.
         """
-        command = f'sudo dhclient {iface_name}'
-        result, _ = execute(command)
-        return result.strip()
+        command = f'dhclient {iface_name}'
+        exec_res = execute(
+            command,
+            params=ExecuteParams(  # noqa: S604
+                run_as_root=True,
+                shell=True,
+            ),
+        )
+        return exec_res.stdout.strip()
 
     def get_default_gateway_ip(self) -> str:
         """Get the default gateway IP for the given interface IP.
@@ -358,14 +444,22 @@ class IPManager:
             NetworkInterfaceException: If setting the default gateway fails.
         """
         LOG.info(f'Setting default gateway: {gateway_ip}')
-        command = f'sudo ip route add default via {gateway_ip}'
-        result, error = execute(command)
+        command = f'ip route add default via {gateway_ip}'
+        exec_res = execute(
+            command,
+            params=ExecuteParams(  # noqa: S604
+                run_as_root=True,
+                shell=True,
+            ),
+        )
 
-        if error:
-            message = f'Failure while setting default gateway: {error}'
+        if exec_res.stderr:
+            message = (
+                f'Failure while setting default gateway: {exec_res.stderr}'
+            )
             raise IPManagerException(message)
 
-        return result.strip()
+        return exec_res.stdout.strip()
 
     def get_json_ifaces(self) -> Dict:
         """Get network interfaces in JSON format.
@@ -379,13 +473,18 @@ class IPManager:
         Raises:
             IPManagerException: If retrieving the network interfaces fails.
         """
-        stdout, stderr = execute('ip -j link show')
-        if stderr:
-            message = stderr
+        command = 'ip -j link show'
+        exec_res = execute(
+            command,
+            params=ExecuteParams(shell=True),  # noqa: S604
+        )
+
+        if exec_res.stderr:
+            message = exec_res.stderr
             raise IPManagerException(message)
 
         # Convert results of commands into dict
-        ifaces: Dict = json.loads(stdout.strip())
+        ifaces: Dict = json.loads(exec_res.stdout.strip())
         return ifaces
 
     def _check_defaoult_gateways(self, addresses: Tuple) -> None:

--- a/openvair/modules/network/domain/utils/netplan_manager.py
+++ b/openvair/modules/network/domain/utils/netplan_manager.py
@@ -17,6 +17,8 @@ import yaml
 
 from openvair.libs.log import get_logger
 from openvair.modules.tools import utils
+from openvair.libs.cli.models import ExecuteParams
+from openvair.libs.cli.executor import execute
 from openvair.modules.network.config import NETPLAN_DIR
 from openvair.modules.tools.jinja_tools import yaml_collector
 from openvair.modules.network.domain.exceptions import (
@@ -51,7 +53,12 @@ class NetplanManager:
     @staticmethod
     def apply() -> None:
         """Apply the current Netplan configuration."""
-        utils.execute('netplan apply', run_as_root=True)
+        execute(
+            'netplan apply',
+            params=ExecuteParams(  # noqa: S604
+                shell=True, run_as_root=True, raise_on_error=True
+            ),
+        )
 
     def create_ovs_bridge_yaml_file(self, data: Dict) -> None:
         """Create a YAML configuration file for an OVS bridge.

--- a/openvair/modules/network/domain/utils/ovs_manager.py
+++ b/openvair/modules/network/domain/utils/ovs_manager.py
@@ -14,7 +14,8 @@ import json
 from typing import Dict, List, Optional
 
 from openvair.libs.log import get_logger
-from openvair.modules.tools.utils import execute
+from openvair.libs.cli.models import ExecuteParams
+from openvair.libs.cli.executor import execute
 from openvair.modules.network.domain.utils.exceptions import (
     OVSManagerException,
     BridgeNotFoundException,
@@ -44,7 +45,7 @@ class OVSManager:
             command_format (str): Base command for OVS management.
             bridge_prefix (str): Prefix for bridge names.
         """
-        self.command_format = 'sudo ovs-vsctl'
+        self.command_format = 'ovs-vsctl'
 
     def _build_command(self, subcommand: str) -> str:
         """Constructs a command with the configured settings.
@@ -73,12 +74,18 @@ class OVSManager:
         """
         command = self._build_command(f'add-br {bridge_name}')
         LOG.info(f'Creating bridge: {bridge_name}')
-        stdout, stderr = execute(command)
-        if stderr:
-            message = f'Error creating bridge {bridge_name}: {stderr}'
+        exec_res = execute(
+            command,
+            params=ExecuteParams(  # noqa: S604
+                run_as_root=True,
+                shell=True,
+            ),
+        )
+        if exec_res.stderr:
+            message = f'Error creating bridge {bridge_name}: {exec_res.stderr}'
             LOG.error(message)
             raise OVSManagerException(message)
-        return stdout.strip()
+        return exec_res.stdout.strip()
 
     def delete_bridge(self, bridge_name: str) -> None:
         """Delete an OVS bridge with the specified name.
@@ -92,8 +99,14 @@ class OVSManager:
         """
         command = self._build_command(f'del-br {bridge_name}')
         LOG.info(f'Deleting bridge: {bridge_name}')
-        stdout, stderr = execute(command)
-        if stderr:
+        exec_res = execute(
+            command,
+            params=ExecuteParams(  # noqa: S604
+                run_as_root=True,
+                shell=True,
+            ),
+        )
+        if exec_res.stderr:
             messsage = (
                 f'Bridge {bridge_name} not found or could not be deleted: '
                 '{stderr}'
@@ -124,15 +137,21 @@ class OVSManager:
             f'Adding interface {iface_name} to bridge '
             f'{bridge_name} with tag {tag}'
         )
-        stdout, stderr = execute(command)
-        if stderr:
+        exec_res = execute(
+            command,
+            params=ExecuteParams(  # noqa: S604
+                run_as_root=True,
+                shell=True,
+            ),
+        )
+        if exec_res.stderr:
             message = (
                 f'Error adding interface {iface_name} to bridge {bridge_name}: '
-                f'{stderr}'
+                f'{exec_res.stderr}'
             )
             LOG.error(message)
             raise InterfaceNotFoundException(message)
-        return stdout.strip()
+        return exec_res.stdout.strip()
 
     def get_ports_in_bridge(self, bridge_name: str) -> List:
         """Retrieve a list of ports within a specified OVS bridge.
@@ -148,12 +167,18 @@ class OVSManager:
             OVSManagerException: If an error occurs while retrieving the ports.
         """
         command = self._build_command(f'list-ports {bridge_name}')
-        stdout, stderr = execute(command)
-        if stderr:
+        exec_res = execute(
+            command,
+            params=ExecuteParams(  # noqa: S604
+                run_as_root=True,
+                shell=True,
+            ),
+        )
+        if exec_res.stderr:
             message = f'Error while getting port in bridge: {bridge_name}'
             LOG.error(message)
             raise OVSManagerException(message)
-        return stdout.split()
+        return exec_res.stdout.split()
 
     def get_bridges(self) -> Dict:
         """Retrieve all OVS bridges in JSON format.
@@ -166,10 +191,16 @@ class OVSManager:
         """
         command = self._build_command('--format=json list bridge')
         LOG.info('Retrieving list of bridges')
-        stdout, stderr = execute(command)
-        if stderr:
-            message = f'Error retrieving bridge list: {stderr}'
+        exec_res = execute(
+            command,
+            params=ExecuteParams(  # noqa: S604
+                run_as_root=True,
+                shell=True,
+            ),
+        )
+        if exec_res.stderr:
+            message = f'Error retrieving bridge list: {exec_res.stderr}'
             LOG.error(message)
             raise OVSManagerException(message)
-        bridges: Dict = json.loads(stdout)
+        bridges: Dict = json.loads(exec_res.stdout)
         return bridges

--- a/openvair/modules/network/utils.py
+++ b/openvair/modules/network/utils.py
@@ -155,7 +155,7 @@ class InterfacesFromSystem(list):
             ),
         )
         duplex = exec_res.stdout
-        return duplex[0].strip() if duplex[0] else None
+        return duplex.strip() if duplex else None
 
     @staticmethod
     def _get_speed_by_name(interface_name: str) -> Optional[str]:
@@ -168,7 +168,7 @@ class InterfacesFromSystem(list):
             ),
         )
         speed = exec_res.stdout
-        return speed[0].strip() if speed[0] else None
+        return speed.strip() if speed else None
 
     @staticmethod
     def _get_slot_port_by_name(interface_name: str) -> Optional[str]:
@@ -195,8 +195,8 @@ class InterfacesFromSystem(list):
             ),
         )
         result = exec_res.stdout
-        if result[0]:
-            slot_port_match = re.search(r'=(.+)', result[0])
+        if result:
+            slot_port_match = re.search(r'=(.+)', result)
             if slot_port_match:
                 return slot_port_match.group(1)
 
@@ -223,7 +223,7 @@ class InterfacesFromSystem(list):
                 shell=True,
             ),
         )
-        result = exec_res.stdout[0]
+        result = exec_res.stdout
         return re.findall(r'/net/(.+)(?:\s|$)', result)
 
     def get_all(self) -> List:  # noqa: D102


### PR DESCRIPTION
## **Обоснование задачи**

В модуле `network` проекта Open vAIR использовались устаревшие вызовы функции `execute` из `openvair/modules/tools/utils.py`. Это снижало надёжность выполнения CLI-команд, усложняло обработку ошибок и делало код менее управляемым. Для унификации работы с CLI-командами и повышения стабильности было решено заменить их на новую версию `execute` из `openvair/libs/cli/executor.py`.

Новая версия `execute` предоставляет:

- Чёткую типизацию параметров через `ExecuteParams`.
- Возвращение результата в виде объекта `ExecutionResult`, содержащего `returncode`, `stdout` и `stderr`.
- Гибкость при передаче параметров окружения и root-прав.

Миграция на новую версию `execute` повысит стабильность выполнения сетевых команд и упростит поддержку кода.

## **Внесённые изменения**

1. **Замена устаревших вызовов `execute`**  
   - Использование новой версии из `openvair.libs.cli.executor`.
   - Вызовы теперь используют параметры через `ExecuteParams`, что делает их более читаемыми.
   - Переменная `stderr` заменена на `exec_res.stderr`, но обработка ошибок осталась такой же.

2. **Обновление модулей:**  
   - `openvair/modules/network/domain/interfaces/physical.py`
   - `openvair/modules/network/domain/interfaces/virtual.py`
   - `openvair/modules/network/domain/utils/ip_manager.py`
   - `openvair/modules/network/domain/utils/netplan_manager.py`
   - `openvair/modules/network/domain/utils/ovs_manager.py`
   - `openvair/modules/network/utils.py`

## **Проверка и тестирование**

- Проведены тесты для проверки корректности работы после миграции.
- Проверена обработка ошибок выполнения сетевых команд.
- Убедились, что функциональность модулей `network` остаётся неизменной.

### Были выявлены баги не связанные с текущими изменениями:
https://github.com/Aerodisk/openvair/issues/117
https://github.com/Aerodisk/openvair/issues/118


## Заведены задачи на рефакторинг:
 `openvair.modules.network.utils.py`: https://github.com/Aerodisk/openvair/issues/113
`openvair.modules.network.domain.utils.ip_manager`: https://github.com/Aerodisk/openvair/issues/112 
