### PR TITLE
Fix mypy error: convert error to string before using re.search

### DIFF
--- a/openvair/modules/volume/domain/base.py
+++ b/openvair/modules/volume/domain/base.py
@@ -121,7 +121,7 @@ class BaseVolume(metaclass=abc.ABCMeta):
             write_lock_warning_pattern = re.compile(
                 r'Failed to get shared "write" lock'
             )
-            if write_lock_warning_pattern.search(err):
+            if write_lock_warning_pattern.search(str(err)):
                 LOG.warning(err)
             else:
                 LOG.error(f'Error executing `qemu-img info`: {err}')


### PR DESCRIPTION
# Исправление ошибки mypy: преобразование ошибки в строку перед использованием re.search

## Описание

Этот pull request устраняет ошибку mypy в файле `../openvair/modules/volume/domain/base.py`. Ошибка возникает из-за того, что `re.search` ожидает строку в качестве первого аргумента, но получает объект типа `Union[ExecuteError, OSError]`.

## Изменения

- Преобразование объекта ошибки в строку перед передачей в `re.search`.

## Обоснование

Изменение гарантирует, что функция `re.search` получает аргумент правильного типа, тем самым устраняя ошибку mypy. Это улучшает безопасность типов и корректность кода.

## Тестирование

- Запуск mypy для проверки отсутствия ошибок типов.
- Проверка, что функциональность остается неизменной и работает как ожидалось.