### PR TITLE
Удаление старого execute из tools в пользу новой версии

### DIFF
--- a/openvair/modules/tools/utils.py
+++ b/openvair/modules/tools/utils.py
@@ -440,6 +440,7 @@ def lip_scan() -> None:
             params=ExecuteParams(  # noqa: S604
                 shell=True,
                 run_as_root=True,
+                raise_on_error=True,
             )
         )
     except (ExecuteError, OSError) as e:
@@ -582,7 +583,8 @@ def get_virsh_list() -> Dict:
         'virsh',
         'list',
         params=ExecuteParams(  # noqa: S604
-            shell=True
+            shell=True,
+            run_as_root=True,
         )
     )
     vms = {}

--- a/openvair/modules/tools/utils.py
+++ b/openvair/modules/tools/utils.py
@@ -38,15 +38,12 @@ Classes:
 
 import os
 import json
-import shlex
-import subprocess
 from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
     List,
     Type,
-    Tuple,
     Union,
     Optional,
     Generator,
@@ -64,6 +61,9 @@ from sqlalchemy.exc import OperationalError
 
 from openvair import config
 from openvair.libs.log import get_logger
+from openvair.libs.cli.models import ExecuteParams, ExecutionResult
+from openvair.libs.cli.executor import execute
+from openvair.libs.cli.exceptions import ExecuteError
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -147,98 +147,6 @@ class NoRootWrapSpecifiedError(Exception):
                 context for the exception.
         """
         super(NoRootWrapSpecifiedError, self).__init__(message)
-
-
-class ExecuteTimeoutExpiredError(Exception):
-    """Raised when a command execution reaches its timeout."""
-
-    def __init__(self, message: Optional[str] = None):
-        """Initialize the ExecuteTimeoutExpiredError.
-
-        Args:
-            message (Optional[str]): An optional error message to provide
-                context for the exception.
-        """
-        super(ExecuteTimeoutExpiredError, self).__init__(message)
-
-
-class ExecuteError(Exception):
-    """General exception for command execution errors."""
-
-    def __init__(self, message: Optional[str] = None):
-        """Initialize the ExecuteError.
-
-        Args:
-            message (Optional[str]): An optional error message to provide
-                context for the exception.
-        """
-        super(ExecuteError, self).__init__(message)
-
-
-def execute(*cmd: str, **kwargs: Any) -> Tuple[str, str]:  # noqa: C901 ANN401 need refact this method TODO need to parameterize the arguments correctly, in accordance with static typing
-    """Runs a shell command and returns the output.
-
-    Args:
-        *cmd: Command and arguments to run.
-        kwargs: Additional options for command execution, such as shell,
-            run_as_root, root_helper, and timeout.
-
-    Returns:
-        Tuple[str, str]: A tuple containing the stdout and stderr output.
-
-    Raises:
-        UnknownArgumentError: If unknown keyword arguments are passed.
-        NoRootWrapSpecifiedError: If run_as_root is True and no root helper is
-            specified.
-        ExecuteTimeoutExpiredError: If the command execution reaches its
-            timeout.
-        OSError: If an OS-level error occurs during command execution.
-    """
-    shell = kwargs.pop('shell', True)
-    run_as_root = kwargs.pop('run_as_root', False)
-    root_helper = kwargs.pop('root_helper', 'sudo')
-    timeout = kwargs.pop('timeout', None)
-    if kwargs:
-        raise UnknownArgumentError('Got unknown keyword args: %r' % kwargs)
-
-    if run_as_root and hasattr(os, 'geteuid') and os.geteuid() != 0:
-        if not root_helper:
-            msg = 'Command requested root, but did not specify a root helper.'
-            raise NoRootWrapSpecifiedError(msg)
-        if shell:
-            cmd = [' '.join((root_helper, cmd[0]))] + list(cmd[1:])  # type: ignore # noqa: RUF005 need refact this method
-        else:
-            cmd = [shlex.split(root_helper) + list(cmd)]  # type: ignore
-    cmd = ' '.join(map(str, cmd))  # type: ignore
-    try:
-        LOG.info('Running cmd (subprocess): %s' % cmd)
-        _pipe = subprocess.PIPE
-
-        proc = subprocess.Popen(  # noqa: S603 need refact this method
-            cmd,
-            shell=shell,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            stdin=subprocess.PIPE,
-        )
-        try:
-            result = proc.communicate(timeout=timeout)
-            proc.stdin.close()  # type: ignore
-            LOG.info('CMD "%s" returned: %s', cmd, proc.returncode)
-            if result is not None:
-                (stdout, stderr) = result
-                stdout = os.fsdecode(stdout)  # type: ignore
-                stderr = os.fsdecode(stderr)  # type: ignore
-                return stdout, stderr  # type: ignore
-        except subprocess.TimeoutExpired as _:
-            LOG.info('CMD "%s" reached timeout', cmd)
-            raise ExecuteTimeoutExpiredError
-        else:
-            return result
-    except OSError as err:
-        message = 'Got an OSError\ncommand: %(cmd)r\nerrno: %(errno)r'
-        LOG.info(message, {'cmd': cmd, 'errno': err.errno})
-        raise
 
 
 def create_access_token(user: Dict, ttl_minutes: Optional[int] = None) -> str:
@@ -394,10 +302,17 @@ def get_block_devices_info() -> List[Dict[str, str]]:
         List[Dict[str, str]]: A dictionary containing information about block
             devices.
     """
-    res, _ = execute(
-        'lsblk', '-bp', '-io', 'NAME,SIZE,TYPE,MOUNTPOINT,UUID,FSTYPE', '--json'
+    res: ExecutionResult = execute(
+        'lsblk',
+        '-bp',
+        '-io',
+        'NAME,SIZE,TYPE,MOUNTPOINT,UUID,FSTYPE',
+        '--json',
+        params=ExecuteParams(  # noqa: S604
+            shell=True,
+        )
     )
-    result: List[Dict[str, str]] = json.loads(res)['blockdevices']
+    result: List[Dict[str, str]] = json.loads(res.stdout)['blockdevices']
     return result
 
 
@@ -520,12 +435,14 @@ def lip_scan() -> None:
     try:
         # Execute the command to issue LIP scan for all Fibre Channel
         # host adapters
-        execute(  # noqa: S604 need refact ececute
+        execute(
             'for i in /sys/class/fc_host/*; do sudo sh -c "echo 1 > $i/issue_lip"; done',  # noqa: E501 because need one line command for better readability
-            shell=True,
-            run_as_root=True,
+            params=ExecuteParams(  # noqa: S604
+                shell=True,
+                run_as_root=True,
+            )
         )
-    except OSError as e:
+    except (ExecuteError, OSError) as e:
         # Handle any errors accessing or writing to the file
         msg = (
             f'Error accessing or writing to /sys/class/fc_host/*/issue_lip: {e}'
@@ -661,7 +578,13 @@ def get_virsh_list() -> Dict:
     Returns:
         Dict: A dictionary containing the names and power states of running VMs.
     """
-    res, _ = execute('virsh', 'list')
+    res: ExecutionResult = execute(
+        'virsh',
+        'list',
+        params=ExecuteParams(  # noqa: S604
+            shell=True
+        )
+    )
     vms = {}
     rows = res.split('\n')[2:-2]
     for row in rows:

--- a/openvair/modules/tools/utils.py
+++ b/openvair/modules/tools/utils.py
@@ -440,7 +440,6 @@ def lip_scan() -> None:
             params=ExecuteParams(  # noqa: S604
                 shell=True,
                 run_as_root=True,
-                raise_on_error=True,
             )
         )
     except (ExecuteError, OSError) as e:


### PR DESCRIPTION
# Описание изменений

Удалён устаревший метод `execute` из `openvair/modules/tools/utils.py`. Это улучшает обработку команд CLI и обеспечивает более строгую типизацию аргументов.

---

# Основные изменения

- Удалены:
  - Функция `execute`, ранее определённая в `utils.py`.
  - Исключения `ExecuteError` и `ExecuteTimeoutExpiredError`, так как теперь они импортируются из `openvair.libs.cli.exceptions`.

- Добавлены:
  - Импорт `ExecuteParams`, `ExecutionResult` и `execute` из `openvair.libs.cli`.
  - Обновлены вызовы `execute`, теперь они используют `ExecuteParams` для настройки аргументов выполнения.
  - Обработано исключение `ExecuteError` в `lip_scan()`.

- Обновлены:
  - `get_block_devices_info()`: Теперь использует `res.stdout` вместо простого `res`, что соответствует типу `ExecutionResult`.
  - `lip_scan()`: Теперь передаёт параметры через `ExecuteParams`, а не как именованные аргументы.
  - `get_virsh_list()`: Аналогично использует `ExecuteParams` при вызове `execute`.

---

# Требования к тестированию

1. **Проверка работы `get_block_devices_info()`**  
   - Вызвать функцию и убедиться, что список блочных устройств корректно формируется на основе JSON-ответа.

2. **Проверка работы `lip_scan()`**  
   - Убедиться, что команда выполняется без ошибок.
   - Проверить, что `ExecuteError` корректно обрабатывается.

3. **Проверка работы `get_virsh_list()`**  
   - Вызвать функцию и убедиться, что список виртуальных машин корректно отображается.

---

# Связанные задачи

- [Issue #116](https://github.com/Aerodisk/openvair/issues/116#issue-2845857968)

---

# Критерии приёмки

- Код успешно собирается и проходит все тесты.
- Функции, использующие `execute`, работают без изменений в поведении.
- Исключения корректно обрабатываются.

---

# Заключение

Замена устаревшего метода `execute` на новую реализацию улучшает безопасность и удобство работы с командами CLI, а также устраняет дублирование кода.
