### PR TITLE
Bug/neplanl_persistence

### DIFF
--- a/openvair/modules/network/domain/bridges/netplan.py
+++ b/openvair/modules/network/domain/bridges/netplan.py
@@ -192,16 +192,22 @@ class NetplanInterface(BaseOVSBridge):
         LOG.info('Start moving params into bridge config...')
         try:
             bridge_data['nameservers'] = main_iface_data.pop('nameservers', [])
-            if main_iface_data.get('dhcp4'):
-                bridge_data['dhcp4'] = 'yes'
-            bridge_data['routes'] = main_iface_data.pop('routes', None)
+            bridge_data['dhcp4'] = main_iface_data.get('dhcp4', False)
+            bridge_data['routes'] = main_iface_data.pop('routes', [])
+            gateway4 = main_iface_data.pop('gateway4', None)
+            if gateway4:
+                bridge_data['routes'].append({
+                    'to': 'default',
+                    'via': gateway4
+                })
+
             bridge_data['addresses'] = list(
                 set(
                     bridge_data.pop('addresses', [])
                     + main_iface_data.pop('addresses', [])
                 )
             )
-            bridge_data['gateway4'] = main_iface_data.pop('gateway4', None)
+
             main_iface_data['dhcp4'] = False
         except Exception as err:
             LOG.error(err)

--- a/openvair/modules/network/domain/bridges/netplan.py
+++ b/openvair/modules/network/domain/bridges/netplan.py
@@ -192,14 +192,12 @@ class NetplanInterface(BaseOVSBridge):
         LOG.info('Start moving params into bridge config...')
         try:
             bridge_data['nameservers'] = main_iface_data.pop('nameservers', [])
-            bridge_data['dhcp4'] = main_iface_data.get('dhcp4', False)
+
+            bridge_data['dhcp4'] = main_iface_data.pop('dhcp4', False)
             bridge_data['routes'] = main_iface_data.pop('routes', [])
             gateway4 = main_iface_data.pop('gateway4', None)
             if gateway4:
-                bridge_data['routes'].append({
-                    'to': 'default',
-                    'via': gateway4
-                })
+                bridge_data['routes'].append({'to': 'default', 'via': gateway4})
 
             bridge_data['addresses'] = list(
                 set(
@@ -209,6 +207,7 @@ class NetplanInterface(BaseOVSBridge):
             )
 
             main_iface_data['dhcp4'] = False
+
         except Exception as err:
             LOG.error(err)
             raise

--- a/openvair/modules/network/domain/bridges/netplan.py
+++ b/openvair/modules/network/domain/bridges/netplan.py
@@ -153,9 +153,6 @@ class NetplanInterface(BaseOVSBridge):
         """
         for iface_name in bridge_data['interfaces']:
             try:
-                # I think it will be necessary to work on stability in this bloc
-                # May be need to check if file have another ifaces and check
-                # configuration for this iface in antoher files
                 LOG.info(f'Restoring backup file for {iface_name}')
                 iface_file = self.netplan_manager.get_path_yaml(iface_name)
             except NetplanFileNotFoundException as err:

--- a/openvair/modules/network/domain/bridges/netplan.py
+++ b/openvair/modules/network/domain/bridges/netplan.py
@@ -201,6 +201,7 @@ class NetplanInterface(BaseOVSBridge):
                     + main_iface_data.pop('addresses', [])
                 )
             )
+            bridge_data['gateway4'] = main_iface_data.pop('gateway4', None)
             main_iface_data['dhcp4'] = False
         except Exception as err:
             LOG.error(err)

--- a/openvair/modules/network/domain/bridges/netplan.py
+++ b/openvair/modules/network/domain/bridges/netplan.py
@@ -283,9 +283,8 @@ class NetplanInterface(BaseOVSBridge):
         if not dhcp4:
             iface_info['addresses'] = [f'{ip}/24'] if ip else None
             if iface_name == self.main_port:
-                iface_info['routes'] = [
-                    {'to': 'default', 'via': self.default_route}
-                ]
+                # добавляем gateway4 явно
+                iface_info['gateway4'] = self.default_route
                 iface_info['nameservers'] = {'addresses': [self.default_route]}
 
         LOG.info(f'Info from {iface_name}: {iface_info}')

--- a/openvair/modules/network/domain/bridges/netplan.py
+++ b/openvair/modules/network/domain/bridges/netplan.py
@@ -290,7 +290,6 @@ class NetplanInterface(BaseOVSBridge):
         if not dhcp4:
             iface_info['addresses'] = [f'{ip}/24'] if ip else None
             if iface_name == self.main_port:
-                # добавляем gateway4 явно
                 iface_info['gateway4'] = self.default_route
                 iface_info['nameservers'] = {'addresses': [self.default_route]}
 


### PR DESCRIPTION
# Описание изменений

Улучшена логика настройки основного сетевого интерфейса при создании моста: теперь IP-адрес и маршруты настраиваются явно и статично, что повышает надёжность конфигурации. Также устранены опечатки и упрощена логика переноса параметров в конфигурацию моста.

---

# Основные изменения

- Исправлены опечатки в логах (`Prepairing` → `Preparing`, `inetrface` → `interface`, `prepaired` → `prepared`).
- В методе `prepare_interfaces`:
  - При обработке основного интерфейса (`main_port`) выполняется:
    - Получение текущего IP и шлюза по умолчанию через `ip_manager`.
    - Обновление конфигурации интерфейса с явным указанием:
      - `dhcp4: False`
      - текущего IP-адреса (`addresses`)
      - маршрутов (`routes`) через `default_gateway`
      - DNS (`nameservers`)
    - Перенос этих параметров в конфигурацию моста.
- Метод `_move_main_port_params_into_bridge` обновлён:
  - `dhcp4`, `routes`, `gateway4`, `addresses` переносятся в `bridge_data`.
  - Значение `gateway4`, если оно есть, добавляется как маршрут `to: default`.
  - DHCP отключается на исходном интерфейсе (`dhcp4: False`).
- Метод `_collect_iface_info` упрощён: вместо `routes` теперь добавляется `gateway4` напрямую.

---

# Связанные задачи

- [BUG: network netplan. Не переносится параметр gateway4 при конфигурации моста с главным портом](https://github.com/Aerodisk/openvair/issues/118)

---

# Требования к тестированию

1. Создать мост с основным интерфейсом, у которого в Netplan не указаны `routes` и `gateway4`.
2. Убедиться, что при применении конфигурации:
   - В логах присутствует сообщение `Adding missing gateway info to <iface_name>`.
   - В конфигурации моста появляются корректные `routes` и `addresses`.
3. Проверить, что после удаления моста параметры основного интерфейса корректно восстанавливаются.

---

# Критерии приёмки

- Интерфейсы с неполной конфигурацией (`routes`, `gateway4`) обрабатываются корректно.
- В логах отображаются понятные и грамматически верные сообщения.
- Поведение не нарушает существующую функциональность при наличии полной конфигурации интерфейсов.

---

# Заключение

Данные изменения повышают устойчивость и читаемость кода при работе с сетевыми интерфейсами Netplan, особенно в условиях, когда конфигурационные данные могут быть неполными или отсутствовать.
