### PR TITLE
Доработка API модуля user для корректного получения списка пользователей

### DIFF
--- a/openvair/modules/user/adapters/repository.py
+++ b/openvair/modules/user/adapters/repository.py
@@ -22,6 +22,7 @@ Methods:
     SqlAlchemyRepository._get: Retrieves a user by ID from the database.
     SqlAlchemyRepository._get_by_name: Retrieves a user by username from
         the database.
+    SqlAlchemyRepository._get_all: Retrieves a list of users from the database.
     SqlAlchemyRepository._delete: Deletes a user by ID from the database.
 """
 
@@ -50,6 +51,7 @@ class AbstractRepository(metaclass=abc.ABCMeta):
         add: Adds a user to the repository.
         get: Retrieves a user by ID from the repository.
         get_by_name: Retrieves a user by username from the repository.
+        get_all: Retrieves a list of users from the database.
         delete: Deletes a user by ID from the repository.
     """
 
@@ -93,6 +95,14 @@ class AbstractRepository(metaclass=abc.ABCMeta):
         """
         return self._get_by_name(username)
 
+    def get_all(self) -> list[User]:
+        """Retrieve a list of users from the database.
+
+        Returns:
+            list[User]: List of all user entities in the database.
+        """
+        return self._get_all()
+
     def delete(self, user_id: UUID) -> None:
         """Delete a user by ID from the repository.
 
@@ -135,6 +145,15 @@ class AbstractRepository(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def _get_all(self) -> list[User]:
+        """Retrieve a list of users from the database.
+
+        Returns:
+            list[User]: List of all user entities in the database.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def _delete(self, user_id: UUID) -> None:
         """Delete a user by ID from the repository.
 
@@ -159,6 +178,7 @@ class SqlAlchemyRepository(AbstractRepository):
         _add: Adds a user to the database.
         _get: Retrieves a user by ID from the database.
         _get_by_name: Retrieves a user by username from the database.
+        _get_all: Retrieves a list of users from the database.
         _delete: Deletes a user by ID from the database.
     """
 
@@ -213,6 +233,14 @@ class SqlAlchemyRepository(AbstractRepository):
             User: The user entity with the specified username.
         """
         return self.session.query(User).filter_by(username=username).one()
+
+    def _get_all(self) -> list[User]:
+        """Retrieve a list of users from the database.
+
+        Returns:
+            list[User]: List of all user entities in the database.
+        """
+        return self.session.query(User).all()
 
     def _delete(self, user_id: UUID) -> None:
         """Delete a user by ID from the database.

--- a/openvair/modules/user/adapters/repository.py
+++ b/openvair/modules/user/adapters/repository.py
@@ -28,7 +28,7 @@ Methods:
 
 import abc
 from uuid import UUID
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from sqlalchemy.exc import OperationalError
 
@@ -95,11 +95,11 @@ class AbstractRepository(metaclass=abc.ABCMeta):
         """
         return self._get_by_name(username)
 
-    def get_all(self) -> list[User]:
+    def get_all(self) -> List[User]:
         """Retrieve a list of users from the database.
 
         Returns:
-            list[User]: List of all user entities in the database.
+            List[User]: List of all user entities in the database.
         """
         return self._get_all()
 
@@ -145,11 +145,11 @@ class AbstractRepository(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def _get_all(self) -> list[User]:
+    def _get_all(self) -> List[User]:
         """Retrieve a list of users from the database.
 
         Returns:
-            list[User]: List of all user entities in the database.
+            List[User]: List of all user entities in the database.
         """
         raise NotImplementedError
 
@@ -234,11 +234,11 @@ class SqlAlchemyRepository(AbstractRepository):
         """
         return self.session.query(User).filter_by(username=username).one()
 
-    def _get_all(self) -> list[User]:
+    def _get_all(self) -> List[User]:
         """Retrieve a list of users from the database.
 
         Returns:
-            list[User]: List of all user entities in the database.
+            List[User]: List of all user entities in the database.
         """
         return self.session.query(User).all()
 

--- a/openvair/modules/user/entrypoints/crud.py
+++ b/openvair/modules/user/entrypoints/crud.py
@@ -11,6 +11,7 @@ Classes:
 
 Methods:
     - get_user(user_id: str) -> Dict: Retrieves user information by user ID.
+    - get_users() -> Dict: Retrieve list of all users.
     - create_user(data: Dict, user_id: str, user_data: Dict) -> Dict: Creates
         a new user.
     - change_password(user_id: str, data: Dict) -> Dict: Changes the password
@@ -21,7 +22,7 @@ Methods:
 """
 
 from uuid import UUID
-from typing import Dict
+from typing import Dict, List
 
 from openvair.libs.log import get_logger
 from openvair.modules.user.config import USER_SERVICE_LAYER_QUEUE_NAME
@@ -40,6 +41,7 @@ class UserCrud:
 
     Methods:
         get_user(user_id: str) -> Dict: Retrieves user information by user ID.
+        get_users() -> Dict: Retrieve list of all users.
         create_user(data: Dict, user_id: str, user_data: Dict) -> Dict: Creates
             a new user.
         change_password(user_id: str, data: Dict) -> Dict: Changes the password
@@ -73,6 +75,18 @@ class UserCrud:
             data_for_method={'user_id': user_id},
         )
         return result
+
+    def get_users(self) -> List:
+        """Retrieve list of all users.
+
+        Returns:
+            List: Information about all users.
+        """
+        LOG.info('Call service layer to get information about all users')
+        return self.service_layer_rpc.call(
+            services.UserManager.get_all_users.__name__,
+            data_for_method={}
+        )
 
     def create_user(
         self,

--- a/openvair/modules/user/entrypoints/crud.py
+++ b/openvair/modules/user/entrypoints/crud.py
@@ -11,7 +11,7 @@ Classes:
 
 Methods:
     - get_user(user_id: str) -> Dict: Retrieves user information by user ID.
-    - get_users() -> Dict: Retrieve list of all users.
+    - get_users() -> List: Retrieve list of all users.
     - create_user(data: Dict, user_id: str, user_data: Dict) -> Dict: Creates
         a new user.
     - change_password(user_id: str, data: Dict) -> Dict: Changes the password
@@ -41,7 +41,7 @@ class UserCrud:
 
     Methods:
         get_user(user_id: str) -> Dict: Retrieves user information by user ID.
-        get_users() -> Dict: Retrieve list of all users.
+        get_users() -> List: Retrieve list of all users.
         create_user(data: Dict, user_id: str, user_data: Dict) -> Dict: Creates
             a new user.
         change_password(user_id: str, data: Dict) -> Dict: Changes the password

--- a/openvair/modules/user/entrypoints/schemas.py
+++ b/openvair/modules/user/entrypoints/schemas.py
@@ -50,17 +50,6 @@ class User(BaseUser):
     model_config = ConfigDict(from_attributes=True)
 
 
-class UsersList(BaseModel):
-    """Schema for representing a list of users.
-
-    Attributes:
-        users (List[Optional[User]]): A list of user objects, which may
-            include None.
-    """
-
-    users: List[Optional[User]]
-
-
 class UserCreate(BaseUser):
     """Schema for user creation including password.
 

--- a/openvair/modules/user/service_layer/services.py
+++ b/openvair/modules/user/service_layer/services.py
@@ -16,7 +16,7 @@ Named tuples:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING, Dict, List
 from collections import namedtuple
 
 from passlib import hash
@@ -105,6 +105,17 @@ class UserManager(BackgroundTasks):
         with self.uow:
             user: User = self.uow.users.get(user_id)
             return DataSerializer.to_web(user)
+
+    def get_all_users(self) -> List:
+        """Retrieve all users from the database.
+
+        Returns:
+            List: List of serialized user data for each user.
+        """
+        LOG.info('Start getting all users from DB')
+        with self.uow:
+            users = self.uow.users.get_all()
+            return [DataSerializer.to_web(user) for user in users]
 
     def authenticate_user(self, data: Dict) -> Dict:
         """Authenticate a user based on provided credentials.


### PR DESCRIPTION
## Issue: #133 

## Изменения:
**Добавлена возможность получения списка пользователей при помощи API-метода: `GET /user/all`**

- В `apy.py` добавлен новый API-эндпоинт (метод `get_users()`) для получения информации о пользователях, который использует в качестве ответа список пользователей с пагинацией (JSONResponse)
- В `UserCrud` (`crud.py`) реализован метод `get_users()`, который запрашивает список всех пользователей через сервисный слой.
- В сервисном слое (`/service_layer/services.py`) добавлен метод `get_all_users` для получения всех пользователей из базы данных в сериализованном формате.
- В `SqlAlchemyRepository` (`/adapters/repository.py`) добавлен метод `get_all()` для получения всех сущностей `user` из БД.

### Замечания:
В решении не была использована схема `schemas.UsersList`, так как для сохранения общего стиля кода (по аналогии с реализацией пагинации в остальных модулях) для `fastapi_pagination` достаточно схемы для пользователя:
`response_model=Page[schemas.User]`. Неиспользованная схема была удалена.

### Результаты:

- [x] Если в базе данных нет пользователей - возвращается `JSONResponse` с пустым списком.
- [x] Сохранена обратная совместимость - существующий метод `get_user` (`GET /user/`) продолжает работать без изменений.
- [x] Реализована поддержка пагинации при помощи `fastapi_pagination`.
- [x] Обновлена документация API - добавлено описание нового эндпоинта `get_users`.

- [x] API возвращает полный список пользователей при запросе `GET /user/all`.
- [x] "_Данные корректно сериализуются в schemas.UsersList_" - вместо этого использована схема `Page[schemas.User]` для поддержки пагинации.
- [x] Логирование успешно фиксирует вызовы нового метода.