### PR TITLE
Bug/backup without storage

### DIFF
--- a/openvair/modules/backup/service_layer/services.py
+++ b/openvair/modules/backup/service_layer/services.py
@@ -227,7 +227,7 @@ class BackupServiceLayerManager(BackgroundTasks):
         move_cmd = f'mv {backup_file} {STORAGE_DATA}'
         execute(
             move_cmd,
-            params=ExecuteParams(  # noqa: S604f
+            params=ExecuteParams(  # noqa: S604
                 shell=True,
                 run_as_root=True,
                 raise_on_error=True,

--- a/openvair/modules/backup/service_layer/services.py
+++ b/openvair/modules/backup/service_layer/services.py
@@ -83,7 +83,7 @@ class BackupServiceLayerManager(BackgroundTasks):
             FSBackuper.backup.__name__,
             data_for_manager=self.__create_data_for_domain_manager(),
         )
-        LOG.info('Backup successfull created')
+        LOG.info('Backup successfully created')
         return result
 
     def delete_snapshot(
@@ -132,7 +132,7 @@ class BackupServiceLayerManager(BackgroundTasks):
             data_for_manager=self.__create_data_for_domain_manager(),
             data_for_method={'snapshot_id': data.get('snapshot_id', 'latest')},
         )
-        LOG.info('Restoring successfull complete')
+        LOG.info('Restoring successfully complete')
         return result
 
     def get_snapshots(self) -> List[Dict]:
@@ -150,7 +150,7 @@ class BackupServiceLayerManager(BackgroundTasks):
             data_for_manager=self.__create_data_for_domain_manager(),
             data_for_method={},
         )
-        LOG.info('Snpashots successfull collected')
+        LOG.info('Snapshots successfully collected')
         return result
 
     def initialize_backup_repository(self) -> None:
@@ -165,7 +165,7 @@ class BackupServiceLayerManager(BackgroundTasks):
             data_for_manager=self.__create_data_for_domain_manager(),
             data_for_method={},
         )
-        LOG.info('Initializing repository successfull complete')
+        LOG.info('Initializing repository successfully complete')
 
     def __dump_database(
         self,
@@ -220,19 +220,19 @@ class BackupServiceLayerManager(BackgroundTasks):
         backup_file = Path(TMP_DIR) / self.backup_file_name
         with backup_file.open('w') as f:
             f.write(dump)
-        LOG.info('Dump seccuessfull written into tmp')
+        LOG.info('Dump successful written into tmp')
 
         LOG.info('Moving dump file into project data dir...')
         move_cmd = f'mv {backup_file} {STORAGE_DATA}'
         execute(
             move_cmd,
-            params=ExecuteParams(  # noqa: S604
+            params=ExecuteParams(  # noqa: S604f
                 shell=True,
                 run_as_root=True,
                 raise_on_error=True,
             ),
         )
-        LOG.info('Dump successfuul moved into project data folder')
+        LOG.info('Dump successfully moved into project data folder')
 
     def __restore_db(self) -> None:
         """Restore the PostgreSQL database from a backup file.

--- a/openvair/modules/backup/service_layer/services.py
+++ b/openvair/modules/backup/service_layer/services.py
@@ -126,12 +126,12 @@ class BackupServiceLayerManager(BackgroundTasks):
                 as returned by the domain layer.
         """
         LOG.info('Start restoring backup')
-        self.__restore_db()
         result: Dict[str, Union[str, int, None]] = self.domain_rpc.call(
             FSBackuper.restore.__name__,
             data_for_manager=self.__create_data_for_domain_manager(),
             data_for_method={'snapshot_id': data.get('snapshot_id', 'latest')},
         )
+        self.__restore_db()
         LOG.info('Restoring successfully complete')
         return result
 
@@ -223,6 +223,7 @@ class BackupServiceLayerManager(BackgroundTasks):
         LOG.info('Dump successful written into tmp')
 
         LOG.info('Moving dump file into project data dir...')
+        STORAGE_DATA.mkdir(exist_ok=True)
         move_cmd = f'mv {backup_file} {STORAGE_DATA}'
         execute(
             move_cmd,


### PR DESCRIPTION
# **Описание**

Ранее в системе возникала ошибка при попытке создания бэкапа до создания хранилища (отсутствие директории `openvair/data`). Это приводило к цепочке ошибок, которая мешала дальнейшей корректной работе модуля бэкапирования: после неудачной попытки создать бэкап также становилось невозможно инициализировать хранилище, т.к. создавался поврежденный файл `data`, вместо директории.

---

# **Описание изменений**

В рамках данного pull request были внесены следующие изменения:

- Добавлено создание директории `STORAGE_DATA` (с флагом `exist_ok=True`) перед переносом дампа базы данных, что предотвращает ошибку при отсутствии этой директории.
- Исправлены многочисленные опечатки в логах
- Обновлён порядок вызовов в методе восстановления (`restore`) для корректного восстановления БД после завершения операции восстановления файлов.

---

# **Требования к приёмке**

- При попытке создать бэкап без предварительно созданного хранилища:
  - Не возникает ошибки, связанной с отсутствием директории `openvair/data`.
- Повторная попытка инициализации хранилища проходит успешно.
- Процесс восстановления БД выполняется корректно после успешного восстановления файлов.
