### PR TITLE
Fix: handle invalid user_id in EventCrud.add_event to prevent UUID conversion errors

### DIFF
--- a/openvair/modules/event_store/entrypoints/crud.py
+++ b/openvair/modules/event_store/entrypoints/crud.py
@@ -118,10 +118,15 @@ class EventCrud:
         """
         try:
             LOG.info('Starting add event')
+            try:
+                user_uuid = uuid.UUID(user_id)
+            except (ValueError, TypeError):
+                LOG.warning(f'Invalid user_id for event: {user_id!r}. Setting user_id to None.')
+                user_uuid = None
             event_info = CreateEventInfo(
                 module=self.module_name,
                 object_id=object_id,
-                user_id=uuid.UUID(user_id),
+                user_id=user_uuid,
                 event=event,
                 information=information,
             )


### PR DESCRIPTION
- Исправлена ошибка преобразования user_id в UUID в методе add_event класса EventCrud.
- Теперь, если user_id не является валидной строкой UUID, в лог пишется предупреждение, а в базу сохраняется None вместо некорректного значения.
- Это предотвращает падение приложения с ошибкой ValueError при добавлении события из сервисного менеджера сети и других частей системы.
- Решает проблему, описанную в issue #111 (https://github.com/Aerodisk/openvair/issues/111).