### PR TITLE
Добавление stdout and stderr в log message UnsuccessReturnCodeError #100

### DIFF
--- a/openvair/libs/cli/executor.py
+++ b/openvair/libs/cli/executor.py
@@ -123,7 +123,9 @@ def execute(
                 if params.raise_on_error and returncode != 0:
                     message = (
                         f"Command '{cmd_str}' failed with return code "
-                        f'{returncode}'
+                        f'{returncode}\n'
+                        f"stdout: {stdout.rstrip()}\n"
+                        f"stderr: {stderr.rstrip()}"
                     )
                     LOG.error(message)
                     raise UnsuccessReturnCodeError(message)


### PR DESCRIPTION
- Сообщения из stderr и stdout теперь выводятся в логе.
- Сначала выведется комманда и её errorcode, потом stdout: "..." и stderr: "...".
- Если в stdout или stderr нет сообщения просто выведется строка "stdout:"
- Функция rstrip() нужна для того, чтобы убрать пробел в конце strout/ strerr, если он там есть 