### PR TITLE
Создание схемы для upload_image, чтобы устранить предупреждение ruff PLR0913 

### DIFF
--- a/openvair/modules/image/entrypoints/api.py
+++ b/openvair/modules/image/entrypoints/api.py
@@ -123,8 +123,8 @@ async def get_image(
     status_code=status.HTTP_200_OK,
 )
 async def upload_image(  # noqa: PLR0913 не возможно передать аргументы как Pydantic схему или Dict,
-    # потому что запрос в формате multipart/form-data тк используется File(...)
-    # для загрузки файла, a FastAPI не умеет автоматически парсить
+    # потому что запрос в формате multipart/form-data из-за использования
+    # File(...) для загрузки файла. FastAPI не умеет автоматически парсить
     # Pydantic-модель или Dict из тела запроса, если запрос multipart/form-data.
     storage_id: UUID,
     description: str = Query(

--- a/openvair/modules/image/entrypoints/api.py
+++ b/openvair/modules/image/entrypoints/api.py
@@ -122,7 +122,10 @@ async def get_image(
     response_model=schemas.Image,
     status_code=status.HTTP_200_OK,
 )
-async def upload_image(  # noqa: PLR0913 need create a schema for arguments
+async def upload_image(  # noqa: PLR0913 не возможно передать аргументы как Pydantic схему или Dict,
+    # потому что запрос в формате multipart/form-data тк используется File(...)
+    # для загрузки файла, a FastAPI не умеет автоматически парсить
+    # Pydantic-модель или Dict из тела запроса, если запрос multipart/form-data.
     storage_id: UUID,
     description: str = Query(
         default='',


### PR DESCRIPTION
- Добавила аргументацию к noqa: PLR0913 (отключение ruff, позволяющее функции upload_image иметь больше 5-ти аргументов) в файле api.py модуля image. 
- input в функцию upload_image не может содержать Dict или Pydentic-model из-за формата передачи данных
- Тк в функции используется File(...) для загрузки файла, данные передаются в формате multipart/form-data, который FastAPI не может автоматически преобразовать в Dict или json 
- Возможным решением было бы использовать Form(...), с помощью которого можно передать данные в виде json строки, а потом преобразовать эту строку в объект schema, но это не очень удобно 