### PR TITLE
Fix/monitoring status

### DIFF
--- a/openvair/modules/storage/service_layer/services.py
+++ b/openvair/modules/storage/service_layer/services.py
@@ -1034,11 +1034,7 @@ class StorageServiceLayerManager(BackgroundTasks):
             StorageStatusError: If the storage status is not valid for
                 monitoring.
         """
-        ...
-        monitoring_statuses = [
-            StorageStatus.available.name,
-            StorageStatus.error.name,
-        ]
+        monitoring_statuses = [status.name for status in StorageStatus]
         self._check_storage_status(
             domain_storage.get('status', ''), monitoring_statuses
         )

--- a/openvair/modules/storage/service_layer/services.py
+++ b/openvair/modules/storage/service_layer/services.py
@@ -1034,7 +1034,10 @@ class StorageServiceLayerManager(BackgroundTasks):
             StorageStatusError: If the storage status is not valid for
                 monitoring.
         """
-        monitoring_statuses = [status.name for status in StorageStatus]
+        monitoring_statuses = [
+            StorageStatus.available.name,
+            StorageStatus.error.name,
+        ]
         self._check_storage_status(
             domain_storage.get('status', ''), monitoring_statuses
         )

--- a/openvair/modules/volume/service_layer/services.py
+++ b/openvair/modules/volume/service_layer/services.py
@@ -1367,7 +1367,10 @@ class VolumeServiceLayerManager(BackgroundTasks):
             )
 
         self._check_storage_on_availability(volume_storage)
-        monitoring_statuses = [status.name for status in VolumeStatus]
+        monitoring_statuses = [
+            status.name for status in VolumeStatus
+            if status.name != VolumeStatus.new.name
+        ]
         self._check_volume_status(
             domain_volume.get('status', ''), monitoring_statuses
         )

--- a/openvair/modules/volume/service_layer/services.py
+++ b/openvair/modules/volume/service_layer/services.py
@@ -1367,8 +1367,9 @@ class VolumeServiceLayerManager(BackgroundTasks):
             )
 
         self._check_storage_on_availability(volume_storage)
+        monitoring_statuses = [status.name for status in VolumeStatus]
         self._check_volume_status(
-            domain_volume.get('status', ''), self._get_monitoring_statuses()
+            domain_volume.get('status', ''), monitoring_statuses
         )
 
         result = self.domain_rpc.call(
@@ -1383,20 +1384,6 @@ class VolumeServiceLayerManager(BackgroundTasks):
             'status': VolumeStatus.available.name,
             'information': '',
         }
-
-    def _get_monitoring_statuses(self) -> List[str]:
-        """Get the list of statuses for monitoring.
-
-        Returns:
-            List[str]: A list of volume statuses to be monitored.
-        """
-        return [
-            VolumeStatus.available.name,
-            VolumeStatus.error.name,
-            VolumeStatus.creating.name,
-            VolumeStatus.deleting.name,
-            VolumeStatus.extending.name,
-        ]
 
     def _update_volumes_in_db(self, updated_db_volumes: List[Dict]) -> None:
         """Update volume information in the database.


### PR DESCRIPTION
# Описание изменений

Унифицирована логика определения мониторинговых статусов хранилищ и томов за счёт использования всех значений соответствующих перечислений (`Enum`), вместо жёстко заданных списков. Также удалён устаревший метод `_get_monitoring_statuses`.

---

# Основные изменения

- В `StorageServiceLayerManager._check_storage_on_availability` список `monitoring_statuses` теперь формируется как `status.name for status in StorageStatus`.
- В `VolumeServiceLayerManager._check_volume_on_availability` список `monitoring_statuses` теперь формируется как `status.name for status in VolumeStatus`.
- Удалён приватный метод `_get_monitoring_statuses`, ранее возвращавший фиксированный список статусов томов.
- Обновлены вызовы `_check_volume_status`, чтобы использовать обновлённый список `monitoring_statuses`.

---

# Требования к тестированию

1. Проверить успешное выполнение методов `check_storage_on_availability` и `check_volume_on_availability` для различных состояний ресурсов, включая все значения `StorageStatus` и `VolumeStatus`.
2. Убедиться, что мониторинг продолжается при любом статусе, входящем в перечисление.
3. Убедиться, что логика отказа при неподдерживаемом статусе работает корректно.

---

# Связанные задачи

- https://github.com/Aerodisk/openvair/issues/202

---

# Критерии приёмки

- Логика проверки статусов построена на основании всех значений `Enum`, а не на жёстко заданных списках.
- Поведение сервисов не изменилось за исключением расширения поддерживаемых статусов.

