### PR TITLE
FIX: Virtual Network. Исправлено сообщение об ошибке создания сети с одинаковыми именами групп портов

### DIFF
--- a/openvair/modules/virtual_network/service_layer/services.py
+++ b/openvair/modules/virtual_network/service_layer/services.py
@@ -158,7 +158,8 @@ class VirtualNetworkServiceLayerManager(BackgroundTasks):
 
         port_group_names = [pg.get('port_group_name') for pg in port_groups]
         if len(port_group_names) != len(set(port_group_names)):
-            message = 'Duplicate port group names.'
+            message = ('Error while creating virtual network: '
+                       'duplicate port group names.')
             raise PortGroupException(message)
 
         db_port_groups = [

--- a/openvair/modules/virtual_network/service_layer/services.py
+++ b/openvair/modules/virtual_network/service_layer/services.py
@@ -154,9 +154,16 @@ class VirtualNetworkServiceLayerManager(BackgroundTasks):
             event=self.create_virtual_network.__name__,
         )
 
+        port_groups = data.pop('port_groups', [])
+
+        port_group_names = [pg.get('port_group_name') for pg in port_groups]
+        if len(port_group_names) != len(set(port_group_names)):
+            message = 'Duplicate port group names.'
+            raise PortGroupException(message)
+
         db_port_groups = [
             cast(PortGroup, DataSerializer.to_db(port_group, PortGroup))
-            for port_group in data.pop('port_groups')
+            for port_group in port_groups
         ]
         db_network = cast(VirtualNetwork, DataSerializer.to_db(data))
         db_network.port_groups = db_port_groups
@@ -480,7 +487,7 @@ class VirtualNetworkServiceLayerManager(BackgroundTasks):
         LOG.info('End monitoring')
 
     def _collect_virsh_virt_net_data(self, net_name: str) -> Dict:
-        """Collectin virtual network info from virhs
+        """Collectin virtual network info from virsh
 
         For collecting port group info this method use xml_to_jsonable from
         tools.utils
@@ -493,12 +500,12 @@ class VirtualNetworkServiceLayerManager(BackgroundTasks):
         autostart = self.virsh_net_adapter.get_network_autostart(uuid)
         persistent = self.virsh_net_adapter.get_network_persistent(uuid)
 
-        virhs_network_data = cast(
+        virsh_network_data = cast(
             Dict, deserialize_xml(xml, attr_prefix='', cdata_key='')
         )
-        pg_info = virhs_network_data['network'].get('portgroup', [])
+        pg_info = virsh_network_data['network'].get('portgroup', [])
         if isinstance(pg_info, Dict):
-            pg_info = [virhs_network_data['network']['portgroup']]
+            pg_info = [virsh_network_data['network']['portgroup']]
         port_groups = self._prepare_port_groups(pg_info)
 
         return {


### PR DESCRIPTION
# Описание изменений

В модуле **Virtual Network** добавлена обработка _**имён групп портов**_ перед созданием виртуальной сети: теперь при наличии одинаковых имён портов данная ошибка корректно обрабатывается **перед** попыткой добавления информации в БД. 

---

# Основные изменения

- В метод `create_virtual_network()` менеджера сервисного слоя добавлена проверка на уникальность `port_group_names`.
- При нахождении неуникальных (дубликатов) имён - вызывается ошибка `PortGroupException` с соответствующим сообщением.
- Новый формат сообщения об ошибке:
`PortGroupException: Error while creating virtual network: duplicate port group names.`

<img width="1078" height="274" alt="image" src="https://github.com/user-attachments/assets/1fafae21-18de-49c0-b855-0062220801d7" />


- *Также был произведён небольшой рефакторинг (исправлена опечатка) в `_collect_virsh_virt_net_data()`.*

---

# Требования к тестированию

1. Смоделировать ситуацию создания виртуальной сети с одинаковыми названиями портгрупп: убедиться в получении корректного сообщения об ошибке (сеть при этом не создаётся).
2. Протестировать ситуацию успешного создания виртуальной сети (с корректными параметрами и различными именами групп портов): убедиться, что сообщение об ошибке не возникает, и сеть успешно создаётся.

---

# Связанные задачи

- **Issue** #215 

---

# Критерии приёмки

- При воспроизведении сообщение об ошибке соответствует новому формату.
- Новая проверка не мешает успешному созданию виртуальной сети при корректных данных.
- Не возникает непредвиденных ошибок работы метода.

