### PR TITLE
Рефакторинг Network: перевод на новый UoW и обновление Repository

### DIFF
--- a/openvair/modules/network/adapters/orm.py
+++ b/openvair/modules/network/adapters/orm.py
@@ -68,9 +68,14 @@ class Interface(Base):
         Integer,
         nullable=True,
     )
-    power_state: Mapped[str] = mapped_column(String(20), nullable=False)
+    power_state: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False
+    )
     status: Mapped[str] = mapped_column(
-        String(20), nullable=False, default='available'
+        String(20),
+        nullable=False,
+        default='available'
     )
 
     extra_specs: Mapped[List['InterfaceExtraSpec']] = relationship(
@@ -78,6 +83,7 @@ class Interface(Base):
         back_populates='interface',
         uselist=True,
         cascade='all, delete-orphan',
+        lazy='selectin',
     )
 
 

--- a/openvair/modules/network/adapters/repository.py
+++ b/openvair/modules/network/adapters/repository.py
@@ -12,7 +12,7 @@ Classes:
         SQLAlchemy for database operations.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from openvair.modules.network.adapters.orm import Interface
 from openvair.common.repositories.base_sqlalchemy import (
@@ -40,7 +40,7 @@ class NetworkSqlAlchemyRepository(BaseSqlAlchemyRepository[Interface]):
         """
         super().__init__(session, Interface)
 
-    def get_by_name(self, interface_name: str) -> Interface:
+    def get_by_name(self, interface_name: str) -> Optional[Interface]:
         """Retrieve a network interface by its name.
 
         Args:
@@ -52,5 +52,5 @@ class NetworkSqlAlchemyRepository(BaseSqlAlchemyRepository[Interface]):
         return (
             self.session.query(Interface)
             .filter_by(name=interface_name)
-            .one()
+            .first()
         )

--- a/openvair/modules/network/adapters/repository.py
+++ b/openvair/modules/network/adapters/repository.py
@@ -12,185 +12,18 @@ Classes:
         SQLAlchemy for database operations.
 """
 
-import abc
-from uuid import UUID
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
-from sqlalchemy.exc import OperationalError
-from sqlalchemy.orm import joinedload
-
-from openvair.abstracts.exceptions import DBCannotBeConnectedError
-from openvair.modules.network.adapters.orm import Interface, InterfaceExtraSpec
+from openvair.modules.network.adapters.orm import Interface
+from openvair.common.repositories.base_sqlalchemy import (
+    BaseSqlAlchemyRepository,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
 
-class AbstractRepository(metaclass=abc.ABCMeta):
-    """Abstract base class for the network interface repository.
-
-    This class defines the interface for interacting with network interface
-    data in the repository. Subclasses must provide implementations for all
-    abstract methods.
-    """
-
-    def _check_connection(self) -> None:
-        """Check the database connection.
-
-        Raises:
-            NotImplementedError: This method should be implemented by
-                subclasses.
-        """
-        raise NotImplementedError
-
-    # Interface
-
-    def add(self, interface: Interface) -> None:
-        """Add a new network interface to the repository.
-
-        Args:
-            interface (Interface): The network interface entity to add.
-        """
-        self._add(interface)
-
-    def get(self, interface_id: UUID) -> Interface:
-        """Retrieve a network interface by its ID.
-
-        Args:
-            interface_id (UUID): The unique identifier of the interface.
-
-        Returns:
-            Interface: The network interface entity matching the given ID.
-        """
-        return self._get(interface_id)
-
-    def get_by_name(self, interface_name: str) -> Interface:
-        """Retrieve a network interface by its name.
-
-        Args:
-            interface_name (str): The name of the interface to retrieve.
-
-        Returns:
-            Interface: The network interface entity matching the given name.
-        """
-        return self._get_by_name(interface_name)
-
-    def get_all(self) -> List[Interface]:
-        """Retrieve all network interfaces from the repository.
-
-        Returns:
-            List: A list of all network interfaces in the repository.
-        """
-        return self._get_all()
-
-    def delete(self, interface_id: UUID) -> None:
-        """Delete a network interface by its ID.
-
-        Args:
-            interface_id (UUID): The unique identifier of the interface to
-                delete.
-        """
-        self._delete(interface_id)
-
-    @abc.abstractmethod
-    def _add(self, interface: Interface) -> None:
-        """Add a new network interface to the repository.
-
-        Args:
-            interface (Interface): The network interface entity to add.
-
-        Raises:
-            NotImplementedError: This method should be implemented by
-                subclasses.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _get(self, interface_id: UUID) -> Interface:
-        """Retrieve a network interface by its ID.
-
-        Args:
-            interface_id (UUID): The unique identifier of the interface.
-
-        Returns:
-            Interface: The network interface entity matching the given ID.
-
-        Raises:
-            NotImplementedError: This method should be implemented by
-                subclasses.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _get_by_name(self, interface_name: str) -> Interface:
-        """Retrieve a network interface by its name.
-
-        Args:
-            interface_name (str): The name of the interface to retrieve.
-
-        Returns:
-            Interface: The network interface entity matching the given name.
-
-        Raises:
-            NotImplementedError: This method should be implemented by
-                subclasses.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _get_all(self) -> List:
-        """Retrieve all network interfaces from the repository.
-
-        Returns:
-            List: A list of all network interfaces in the repository.
-
-        Raises:
-            NotImplementedError: This method should be implemented by
-                subclasses.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _delete(self, interface_id: UUID) -> None:
-        """Delete a network interface by its ID.
-
-        Args:
-            interface_id (UUID): The unique identifier of the interface to
-                delete.
-
-        Raises:
-            NotImplementedError: This method should be implemented by
-                subclasses.
-        """
-        raise NotImplementedError
-
-    # InterfaceExtraSpec
-
-    def delete_extra_specs(self, interface_id: UUID) -> None:
-        """Delete all extra specifications for a given interface.
-
-        Args:
-            interface_id (UUID): The ID of the interface whose extra
-                specifications are to be deleted.
-        """
-        self._delete_extra_specs(interface_id)
-
-    @abc.abstractmethod
-    def _delete_extra_specs(self, interface_id: UUID) -> None:
-        """Delete all extra specifications for a given interface.
-
-        Args:
-            interface_id (UUID): The ID of the interface whose extra
-                specifications are to be deleted.
-
-        Raises:
-            NotImplementedError: This method should be implemented by
-                subclasses.
-        """
-        raise NotImplementedError
-
-
-class SqlAlchemyRepository(AbstractRepository):
+class NetworkSqlAlchemyRepository(BaseSqlAlchemyRepository[Interface]):
     """SQLAlchemy-based implementation of the network interface repository.
 
     This class provides concrete implementations of the methods defined in
@@ -205,50 +38,9 @@ class SqlAlchemyRepository(AbstractRepository):
             session (Session): The SQLAlchemy session to use for database
                 operations.
         """
-        super(SqlAlchemyRepository, self).__init__()
-        self.session: Session = session
-        self._check_connection()
+        super().__init__(session, Interface)
 
-    def _check_connection(self) -> None:
-        """Check the database connection.
-
-        This method attempts to establish a connection to the database
-        and raises a `DBCannotBeConnectedError` if the connection fails.
-
-        Raises:
-            DBCannotBeConnectedError: If the database connection cannot be
-                established.
-        """
-        try:
-            self.session.connection()
-        except OperationalError:
-            raise DBCannotBeConnectedError(message="Can't connect to Database")
-
-    def _add(self, interface: Interface) -> None:
-        """Add a new network interface to the repository.
-
-        Args:
-            interface (Interface): The network interface entity to add.
-        """
-        self.session.add(interface)
-
-    def _get(self, interface_id: UUID) -> Interface:
-        """Retrieve a network interface by its ID.
-
-        Args:
-            interface_id (UUID): The unique identifier of the interface.
-
-        Returns:
-            Interface: The network interface entity matching the given ID.
-        """
-        return (
-            self.session.query(Interface)
-            .options(joinedload(Interface.extra_specs))
-            .filter_by(id=interface_id)
-            .one()
-        )
-
-    def _get_by_name(self, interface_name: str) -> Interface:
+    def get_by_name(self, interface_name: str) -> Interface:
         """Retrieve a network interface by its name.
 
         Args:
@@ -259,39 +51,6 @@ class SqlAlchemyRepository(AbstractRepository):
         """
         return (
             self.session.query(Interface)
-            .options(joinedload(Interface.extra_specs))
             .filter_by(name=interface_name)
             .one()
         )
-
-    def _get_all(self) -> List[Interface]:
-        """Retrieve all network interfaces from the repository.
-
-        Returns:
-            List[Interface]: A list of all network interfaces in the repository.
-        """
-        return (
-            self.session.query(Interface)
-            .options(joinedload(Interface.extra_specs))
-            .all()
-        )
-
-    def _delete(self, interface_id: UUID) -> None:
-        """Delete a network interface by its ID.
-
-        Args:
-            interface_id (UUID): The unique identifier of the interface to
-                delete.
-        """
-        self.session.query(Interface).filter_by(id=interface_id).delete()
-
-    def _delete_extra_specs(self, interface_id: UUID) -> None:
-        """Delete all extra specifications for a given interface.
-
-        Args:
-            interface_id (UUID): The ID of the interface whose extra
-                specifications are to be deleted.
-        """
-        self.session.query(InterfaceExtraSpec).filter_by(
-            interface_id=interface_id
-        ).delete()

--- a/openvair/modules/network/service_layer/exceptions.py
+++ b/openvair/modules/network/service_layer/exceptions.py
@@ -95,9 +95,9 @@ class NestedOVSBridgeNotAllowedError(BaseCustomException):
         super().__init__(message, *args)
 
 
-class InerfaceAllreadyExistException(BaseCustomException):
-    """Raised when try create inetrface with existing name"""
+class InterfaceAllreadyExistException(BaseCustomException):
+    """Raised when try create interface with existing name"""
 
     def __init__(self, message: str, *args: Any) -> None:  # noqa: ANN401 # TODO need to parameterize the arguments correctly, in accordance with static typing
-        """Initialize InerfaceAllreadyExistException"""
+        """Initialize InterfaceAllreadyExistException"""
         super().__init__(message, *args)

--- a/openvair/modules/network/service_layer/exceptions.py
+++ b/openvair/modules/network/service_layer/exceptions.py
@@ -95,9 +95,9 @@ class NestedOVSBridgeNotAllowedError(BaseCustomException):
         super().__init__(message, *args)
 
 
-class InterfaceAllreadyExistException(BaseCustomException):
+class InterfaceAlreadyExistException(BaseCustomException):
     """Raised when try create interface with existing name"""
 
     def __init__(self, message: str, *args: Any) -> None:  # noqa: ANN401 # TODO need to parameterize the arguments correctly, in accordance with static typing
-        """Initialize InterfaceAllreadyExistException"""
+        """Initialize InterfaceAlreadyExistException"""
         super().__init__(message, *args)

--- a/openvair/modules/network/service_layer/services.py
+++ b/openvair/modules/network/service_layer/services.py
@@ -467,6 +467,7 @@ class NetworkServiceLayerManager(BackgroundTasks):
                 except SQLAlchemyError as e:
                     message = f'Failed to delete interface from DB: {e}.'
                     LOG.error(message)
+                    raise exceptions.InterfaceDeletingError(message)
 
     def _edit_interface_in_db(self, data: Dict) -> Dict:
         """Edit a network interface and its extra specs in the database.

--- a/openvair/modules/network/service_layer/services.py
+++ b/openvair/modules/network/service_layer/services.py
@@ -526,7 +526,7 @@ class NetworkServiceLayerManager(BackgroundTasks):
     def _check_existance_and_port_compabilities(self, data: Dict) -> None:
         interfaces = self.get_all_interfaces(data)
         if data['name'] in [bridge['name'] for bridge in interfaces]:
-            error = exceptions.InterfaceAllreadyExistException(data['name'])
+            error = exceptions.InterfaceAlreadyExistException(data['name'])
             LOG.error(error)
             raise error
 

--- a/openvair/modules/network/service_layer/services.py
+++ b/openvair/modules/network/service_layer/services.py
@@ -212,7 +212,15 @@ class NetworkServiceLayerManager(BackgroundTasks):
         """
         self._check_existance_and_port_compabilities(data)
         create_iface_info = self._validate_create_interface_info(data)
-        web_iface = self._create_interface_in_db(create_iface_info._asdict())
+        try:
+            web_iface = self._create_interface_in_db(
+                create_iface_info._asdict()
+            )
+        except SQLAlchemyError as e:
+            message = f'Failed to create interface in db: {e}.'
+            LOG.error(message)
+            raise exceptions.InterfaceInsertionError(message)
+
         data.update({'iface_id': web_iface.get('id', '')})
         self.service_layer_rpc.cast(
             self._create_bridge.__name__, data_for_method=data

--- a/openvair/modules/network/service_layer/services.py
+++ b/openvair/modules/network/service_layer/services.py
@@ -726,21 +726,21 @@ class NetworkServiceLayerManager(BackgroundTasks):
         for db_iface_name in db_interfaces:
             with self.uow() as uow:
                 db_iface = uow.interfaces.get_by_name(db_iface_name)
-                if db_iface:
-                    if db_iface_name.startswith('ovs-system') or any(
-                        db_iface_name.startswith(prefix) for prefix
-                        in prefixes_to_delete
-                    ):
-                        uow.interfaces.delete(db_iface)
-                    # Set the status to 'error' for all other interfaces
-                    else:
-                        LOG.info(
-                            f'Interface {db_iface_name!r} not found in os. '
-                            f'Setting status to error for '
-                            f'interface {db_iface!r}.'
-                        )
-                        db_iface.status = InterfaceStatus.error.name
-                    uow.commit()
+                if not db_iface:
+                    continue
+                if db_iface_name.startswith('ovs-system') or any(
+                    db_iface_name.startswith(prefix) for prefix
+                    in prefixes_to_delete
+                ):
+                    uow.interfaces.delete(db_iface)
+                else:
+                    LOG.info(
+                        f'Interface {db_iface_name!r} not found in os. '
+                        f'Setting status to error for '
+                        f'interface {db_iface!r}.'
+                    )
+                    db_iface.status = InterfaceStatus.error.name
+                uow.commit()
 
         LOG.info('Stop monitoring')
 

--- a/openvair/modules/network/service_layer/services.py
+++ b/openvair/modules/network/service_layer/services.py
@@ -376,14 +376,12 @@ class NetworkServiceLayerManager(BackgroundTasks):
         with self.uow() as uow:
             db_iface = uow.interfaces.get_or_fail(iface_id)
             LOG.info("Changing interface state on 'new'")
-            # write a new state in database
             db_iface.status = InterfaceStatus.creating.name
             uow.commit()
 
         with self.uow() as uow:
             db_iface = uow.interfaces.get_or_fail(iface_id)
             try:
-                # Actually create a new bridge
                 LOG.info('Start calling domain layer to create a new bridge.')
                 result = self.domain_rpc.call(
                     BaseBridge.create.__name__,
@@ -391,7 +389,6 @@ class NetworkServiceLayerManager(BackgroundTasks):
                     data_for_method=data,
                 )
                 LOG.info('Result of rpc call to domain: %s.' % result)
-                # Set state as available
                 db_iface.status = InterfaceStatus.available.name
                 LOG.info(
                     'Interface state was updated on %s.'

--- a/openvair/modules/network/service_layer/services.py
+++ b/openvair/modules/network/service_layer/services.py
@@ -80,7 +80,7 @@ class NetworkServiceLayerManager(BackgroundTasks):
             layer.
         service_layer_rpc (Protocol): RPC protocol for communicating within the
             service layer.
-        uow (SqlAlchemyUnitOfWork): Unit of work instance for managing
+        uow (NetworkSqlAlchemyUnitOfWork): Unit of work instance for managing
             database transactions.
         event_store (EventCrud): Event store for logging events related to
             network operations.
@@ -101,7 +101,7 @@ class NetworkServiceLayerManager(BackgroundTasks):
         self.service_layer_rpc = MessagingClient(
             queue_name=API_SERVICE_LAYER_QUEUE_NAME
         )
-        self.uow = unit_of_work.SqlAlchemyUnitOfWork()
+        self.uow = unit_of_work.NetworkSqlAlchemyUnitOfWork
         self.event_store = EventCrud('networks')
 
     def get_all_interfaces(
@@ -125,9 +125,9 @@ class NetworkServiceLayerManager(BackgroundTasks):
         LOG.info('Start getting all interfaces from db.')
         is_need_filter = data.pop('is_need_filter', None)
         filterable_ifaces_names = ['lo']
-        with self.uow:
+        with self.uow() as uow:
             web_interfaces = []
-            db_interfaces = self.uow.interfaces.get_all()
+            db_interfaces = uow.interfaces.get_all()
             for db_iface in db_interfaces:
                 if not (
                     is_need_filter and db_iface.name in filterable_ifaces_names
@@ -162,8 +162,8 @@ class NetworkServiceLayerManager(BackgroundTasks):
             )
             LOG.error(message)
             raise exceptions.UnexpectedDataArguments(message)
-        with self.uow:
-            db_iface = self.uow.interfaces.get(iface_id)
+        with self.uow() as uow:
+            db_iface = uow.interfaces.get_or_fail(iface_id)
             web_iface = DataSerializer.to_web(db_iface)
             LOG.debug('Got interface from db: %s.' % web_iface)
         LOG.info(
@@ -212,31 +212,13 @@ class NetworkServiceLayerManager(BackgroundTasks):
         """
         self._check_existance_and_port_compabilities(data)
         create_iface_info = self._validate_create_interface_info(data)
-        try:
-            with self.uow:
-                db_iface = cast(
-                    orm.Interface,
-                    DataSerializer.to_db(create_iface_info._asdict()),
-                )
-                LOG.info('Start inserting interface into db.')
-                self.uow.interfaces.add(db_iface)
-                self.uow.commit()
-                serialized_iface = DataSerializer.to_web(db_iface)
-                LOG.debug(
-                    'Serialized interface ready for other steps: %s'
-                    % serialized_iface
-                )
-        except SQLAlchemyError as e:
-            message = f'Failed to insert interface into db: {e}.'
-            LOG.error(message)
-            raise exceptions.InterfaceInsertionError(message)
-
-        data.update({'iface_id': serialized_iface.get('id', '')})
+        web_iface = self._create_interface_in_db(create_iface_info._asdict())
+        data.update({'iface_id': web_iface.get('id', '')})
         self.service_layer_rpc.cast(
             self._create_bridge.__name__, data_for_method=data
         )
         LOG.info('Service layer start creating bridge.')
-        return serialized_iface
+        return web_iface
 
     def delete_bridge(self, data: Dict) -> Dict:
         """Delete a network bridge.
@@ -265,17 +247,15 @@ class NetworkServiceLayerManager(BackgroundTasks):
             LOG.error(message)
             raise exceptions.UnexpectedDataArguments(message)
 
-        with self.uow:
-            db_iface = self.uow.interfaces.get(iface_id)
+        with self.uow() as uow:
+            db_iface = uow.interfaces.get_or_fail(iface_id)
             data['name'] = db_iface.name
             try:
                 db_iface.status = InterfaceStatus.deleting.name
-                self.uow.commit()
+                uow.commit()
                 serialized_iface = DataSerializer.to_web(db_iface)
             except SQLAlchemyError as e:
                 message = f'Failed to delete interface from db: {e}.'
-                db_iface.status = InterfaceStatus.error.name
-                self.uow.commit()
                 LOG.error(message)
                 raise exceptions.InterfaceDeletingError(message)
 
@@ -301,8 +281,8 @@ class NetworkServiceLayerManager(BackgroundTasks):
         iface_name = data.get('name', '')
         LOG.info(f'Interface name: {iface_name}')
 
-        with self.uow:
-            db_iface = self.uow.interfaces.get_by_name(iface_name)
+        with self.uow() as uow:
+            db_iface = uow.interfaces.get_by_name(iface_name)
             domain_iface = DataSerializer.to_domain(db_iface)
 
         LOG.info('Sending enable interface command to domain layer...')
@@ -333,8 +313,8 @@ class NetworkServiceLayerManager(BackgroundTasks):
         LOG.info(f'Interface name: {iface_name}')
 
         LOG.info('Sending disable interface command to domain layer...')
-        with self.uow:
-            db_iface = self.uow.interfaces.get_by_name(iface_name)
+        with self.uow() as uow:
+            db_iface = uow.interfaces.get_by_name(iface_name)
             domain_iface = DataSerializer.to_domain(db_iface)
 
         self.domain_rpc.cast(
@@ -375,13 +355,16 @@ class NetworkServiceLayerManager(BackgroundTasks):
             LOG.error(message)
             raise exceptions.CreateInterfaceDataException(message)
 
-        with self.uow:
-            db_iface = self.uow.interfaces.get(iface_id)
+        with self.uow() as uow:
+            db_iface = uow.interfaces.get_or_fail(iface_id)
+            LOG.info("Changing interface state on 'new'")
+            # write a new state in database
+            db_iface.status = InterfaceStatus.creating.name
+            uow.commit()
+
+        with self.uow() as uow:
+            db_iface = uow.interfaces.get_or_fail(iface_id)
             try:
-                LOG.info("Changing interface state on 'new'")
-                # write a new state in database
-                db_iface.status = InterfaceStatus.creating.name
-                self.uow.commit()
                 # Actually create a new bridge
                 LOG.info('Start calling domain layer to create a new bridge.')
                 result = self.domain_rpc.call(
@@ -415,7 +398,7 @@ class NetworkServiceLayerManager(BackgroundTasks):
                 )
                 raise exceptions.InterfaceInsertionError(message)
             finally:
-                self.uow.commit()
+                uow.commit()
 
     def _delete_bridge(self, data: Dict) -> None:
         """Helper method to delete a network bridge.
@@ -435,8 +418,8 @@ class NetworkServiceLayerManager(BackgroundTasks):
         user_id = user_info.get('id', '')
         iface_id = data.get('id', '')
 
-        with self.uow:
-            db_iface = self.uow.interfaces.get(iface_id)
+        with self.uow() as uow:
+            db_iface = uow.interfaces.get_or_fail(iface_id)
             try:
                 self.domain_rpc.call(
                     BaseBridge.delete.__name__,
@@ -454,15 +437,14 @@ class NetworkServiceLayerManager(BackgroundTasks):
                     f'domain layer while deleting the bridge: {err!s}'
                 )
                 db_iface.status = InterfaceStatus.error.name
-                self.uow.commit()
                 LOG.error(message)
                 self.event_store.add_event(
                     iface_id, user_id, self._delete_bridge.__name__, message
                 )
                 raise exceptions.InterfaceDeletingError(message)
             finally:
-                self.uow.interfaces.delete(iface_id)
-                self.uow.commit()
+                uow.commit()
+                self._delete_interface_from_db(data)
 
     def _edit_interface_in_db(self, data: Dict) -> Dict:
         """Edit a network interface and its extra specs in the database.
@@ -484,8 +466,8 @@ class NetworkServiceLayerManager(BackgroundTasks):
         """
         LOG.info('Service layer start handling response on edit interface.')
         interface_name = data.get('name', '')
-        with self.uow:
-            db_interface = self.uow.interfaces.get_by_name(interface_name)
+        with self.uow() as uow:
+            db_interface = uow.interfaces.get_by_name(interface_name)
             if not db_interface:
                 message = (
                     'Interface with name %s is not found in DB.'
@@ -514,8 +496,8 @@ class NetworkServiceLayerManager(BackgroundTasks):
             specs = data.get('specs', {})
             self._update_extra_specs(db_interface, specs)
 
-            self.uow.interfaces.add(db_interface)
-            self.uow.commit()
+            uow.interfaces.add(db_interface)
+            uow.commit()
 
             return DataSerializer.to_web(db_interface)
 
@@ -547,7 +529,7 @@ class NetworkServiceLayerManager(BackgroundTasks):
                 data.
         """
         LOG.info('Service layer start handling response on create interface.')
-        with self.uow:
+        with self.uow() as uow:
             db_interface = cast(orm.Interface, DataSerializer.to_db(data))
             for key, value in data.get('specs', {}).items():
                 spec = {
@@ -561,8 +543,8 @@ class NetworkServiceLayerManager(BackgroundTasks):
                         DataSerializer.to_db(spec, orm.InterfaceExtraSpec),
                     )
                 )
-            self.uow.interfaces.add(db_interface)
-            self.uow.commit()
+            uow.interfaces.add(db_interface)
+            uow.commit()
             LOG.info('Interface inserted into db: %s.' % db_interface)
 
         web_interface = DataSerializer.to_web(db_interface)
@@ -588,8 +570,8 @@ class NetworkServiceLayerManager(BackgroundTasks):
         """
         LOG.info('Service layer start handling response on delete interface.')
         interface_id = data.get('id', '')
-        with self.uow:
-            db_interface = self.uow.interfaces.get(interface_id)
+        with self.uow() as uow:
+            db_interface = uow.interfaces.get_or_fail(interface_id)
             if not db_interface:
                 message = (
                     'Interface with id %s is not found in DB.' % interface_id
@@ -599,10 +581,9 @@ class NetworkServiceLayerManager(BackgroundTasks):
 
             domain_interface = DataSerializer.to_domain(db_interface)
             LOG.debug('Got interface: %s from db.' % domain_interface)
-            self.uow.interfaces.delete_extra_specs(interface_id)
-            self.uow.interfaces.delete(interface_id)
+            uow.interfaces.delete(db_interface)
             LOG.info('Interface: %s deleted from db.' % interface_id)
-            self.uow.commit()
+            uow.commit()
         LOG.info(
             'Service layer method delete interface was successfully processed'
         )
@@ -702,36 +683,41 @@ class NetworkServiceLayerManager(BackgroundTasks):
         }
 
         LOG.debug('Got interfaces from system %s' % interfaces_from_os)
-        with self.uow:
+        with self.uow() as uow:
             db_interfaces = {
-                iface.name: iface for iface in self.uow.interfaces.get_all()
+                iface.name: iface for iface in uow.interfaces.get_all()
             }
-
             LOG.debug('Got interfaces from db %s' % db_interfaces)
+
+        if db_interfaces:
             for (os_iface_name), os_iface_data in interfaces_from_os.items():
-                db_interface = self.__synchronize_os_to_db_info(
-                    os_iface_data,
-                    db_interfaces.get(os_iface_name),
-                )
-                db_interface.status = InterfaceStatus.available.name
-                self.uow.interfaces.add(db_interface)
-                db_interfaces.pop(os_iface_name, None)
+                with self.uow() as uow:
+                    db_interface = self.__synchronize_os_to_db_info(
+                        os_iface_data,
+                        db_interfaces.get(os_iface_name),
+                    )
+                    db_interface.status = InterfaceStatus.available.name
+                    uow.interfaces.add(db_interface)
+                    db_interfaces.pop(os_iface_name, None)
+                    uow.commit()
 
             prefixes_to_delete = ['vnet', 'veth']
             for db_iface_name, db_iface in db_interfaces.items():
-                if db_iface_name.startswith('ovs-system') or any(
-                    db_iface_name.startswith(prefix) for prefix
-                    in prefixes_to_delete
-                ):
-                    self.uow.interfaces.delete(db_iface.id)
-                # Set the status to 'error' for all other interfaces
-                else:
-                    LOG.info(
-                        f'Interface {db_iface_name!r} not found in os. '
-                        f'Setting status to error for interface {db_iface!r}.'
-                    )
-                    db_iface.status = InterfaceStatus.error.name
-            self.uow.commit()
+                with self.uow() as uow:
+                    if db_iface_name.startswith('ovs-system') or any(
+                        db_iface_name.startswith(prefix) for prefix
+                        in prefixes_to_delete
+                    ):
+                        uow.interfaces.delete(db_iface)
+                    # Set the status to 'error' for all other interfaces
+                    else:
+                        LOG.info(
+                            f'Interface {db_iface_name!r} not found in os. '
+                            f'Setting status to error for '
+                            f'interface {db_iface!r}.'
+                        )
+                        db_iface.status = InterfaceStatus.error.name
+                    uow.commit()
 
         LOG.info('Stop monitoring')
 


### PR DESCRIPTION
# Описание изменений

Произведён перевод модуля **Network** на использование нового формата ***Unit of Work*** и ***Repository***. Реализовано использование унифицированных базовых классов `BaseSqlAlchemyRepository` и `BaseSqlAlchemyUnitOfWork` в качестве родительских для новых  `NetworkSqlAlchemyRepository` и `NetworkSqlAlchemyUnitOfWork`. Сервисный менеджер обновлён для работы с новыми классами, переработано использование контекстного менеджера, произведён необходимый рефакторинг.


# Ключевые изменения

- Удалены устаревшие классы репозитория и UoW: `SqlAlchemyRepository` и `SqlAlchemyUnitOfWork`, а также их абстракции в модуле.

- Реализован репозиторий `NetworkSqlAlchemyRepository`, наследуемый от `BaseSqlAlchemyRepository`: 
	- Из репозитория исключены общие методы, уже реализованные в базовом репозитории. 
	- Удалён метод `delete_extra_specs()` и его использование в сервисном слое, так как в нём нет необходимости: в ORM-схеме для соответствующей связи используется параметр `cascade='all, delete-orphan'`
	- Изменена реализация метода `get_by_name()` - теперь он возвращает найденный объект `Interface` или `None` (параметр запроса `.first()` вместо `.one()`). Это сделано для корректной работы  с методом в изменённом сервисном менеджере.

- Реализован Unit of Work `NetworkSqlAlchemyUnitOfWork`, наследуемый от `BaseSqlAlchemyUnitOfWork`, в нём добавлен метод `_init_repositories()` для инициализации репозиториев модуля.

- Обновлён сервисный менеджер `NetworkServiceLayerManager` в сервисном слое (`services.py`):
	- Заменено использование `SqlAlchemyUnitOfWork` на `NetworkSqlAlchemyUnitOfWork`.
	- Обновлена работа с контекстным менеджером в новом формате: `with self.uow() as uow`. Соблюдён принцип *"одно действие - один коммит и закрытие контекста"*.
	- Переработана логика мониторинга (метод `monitoring()`) для корректной работы с новым форматом контекстного менеджера.
	- Исправлены небольшие опечатки и недочёты.
	- Сохранена обратная совместимость для существующих методов.

- Обновлена ORM-схема `Network` - для связи с таблицей `'InterfaceExtraSpec'` добавлен параметр `lazy='selectin'` (для исключения использования `joinedload`)


# Критерии приёмки

- [x] Модуль `network` использует новые общие абстракции `BaseSqlAlchemyRepository` и `BaseSqlAlchemyUnitOfWork`.
- [x] Удалены старые классы репозитория и UoW, связанные с `network`.
- [x] Эндпоинты модуля работают корректно, все действия с сетевыми интерфейсами проходят успешно 
(за исключением уже описанной ранее **issue** #117 - данная проблема сохраняется).


# Связанные задачи

- **Issue** #219 
