### PR TITLE
Рефакторинг uow и repository в модуле User

### DIFF
--- a/openvair/modules/user/adapters/repository.py
+++ b/openvair/modules/user/adapters/repository.py
@@ -26,144 +26,17 @@ Methods:
     SqlAlchemyRepository._delete: Deletes a user by ID from the database.
 """
 
-import abc
-from uuid import UUID
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
-from sqlalchemy.exc import OperationalError
-
-from openvair.abstracts.exceptions import DBCannotBeConnectedError
 from openvair.modules.user.adapters.orm import User
+from openvair.common.repositories.base_sqlalchemy import (
+    BaseSqlAlchemyRepository,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
-
-class AbstractRepository(metaclass=abc.ABCMeta):
-    """Abstract base class for user repository operations.
-
-    This class defines the interface for managing user entities in the
-    repository. It includes abstract methods for adding, retrieving, and
-    deleting users.
-
-    Methods:
-        _check_connection: Abstract method to check the database connection.
-        add: Adds a user to the repository.
-        get: Retrieves a user by ID from the repository.
-        get_by_name: Retrieves a user by username from the repository.
-        get_all: Retrieves a list of users from the database.
-        delete: Deletes a user by ID from the repository.
-    """
-
-    def _check_connection(self) -> None:
-        """Check the database connection.
-
-        This method must be implemented in subclasses to ensure that the
-        repository is properly connected to the database.
-        """
-        raise NotImplementedError
-
-    # User operation
-
-    def add(self, user: User) -> None:
-        """Add a user to the repository.
-
-        Args:
-            user (User): The user entity to add.
-        """
-        self._add(user)
-
-    def get(self, user_id: UUID) -> User:
-        """Retrieve a user by ID from the repository.
-
-        Args:
-            user_id (UUID): The ID of the user to retrieve.
-
-        Returns:
-            User: The user entity with the specified ID.
-        """
-        return self._get(user_id)
-
-    def get_by_name(self, username: str) -> User:
-        """Retrieve a user by username from the repository.
-
-        Args:
-            username (str): The username of the user to retrieve.
-
-        Returns:
-            User: The user entity with the specified username.
-        """
-        return self._get_by_name(username)
-
-    def get_all(self) -> List[User]:
-        """Retrieve a list of users from the database.
-
-        Returns:
-            List[User]: List of all user entities in the database.
-        """
-        return self._get_all()
-
-    def delete(self, user_id: UUID) -> None:
-        """Delete a user by ID from the repository.
-
-        Args:
-            user_id (UUID): The ID of the user to delete.
-        """
-        self._delete(user_id)
-
-    @abc.abstractmethod
-    def _add(self, user: User) -> None:
-        """Add a user to the repository.
-
-        Args:
-            user (User): The user entity to add.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _get(self, user_id: UUID) -> User:
-        """Retrieve a user by ID from the repository.
-
-        Args:
-            user_id (UUID): The ID of the user to retrieve.
-
-        Returns:
-            User: The user entity with the specified ID.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _get_by_name(self, username: str) -> User:
-        """Retrieve a user by username from the repository.
-
-        Args:
-            username (str): The username of the user to retrieve.
-
-        Returns:
-            User: The user entity with the specified username.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _get_all(self) -> List[User]:
-        """Retrieve a list of users from the database.
-
-        Returns:
-            List[User]: List of all user entities in the database.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _delete(self, user_id: UUID) -> None:
-        """Delete a user by ID from the repository.
-
-        Args:
-            user_id (UUID): The ID of the user to delete.
-        """
-        raise NotImplementedError
-
-
-class SqlAlchemyRepository(AbstractRepository):
+class SqlAlchemyRepository(BaseSqlAlchemyRepository[User]):
     """Concrete implementation of AbstractRepository using SQLAlchemy.
 
     This class provides the actual implementation of repository methods
@@ -188,42 +61,9 @@ class SqlAlchemyRepository(AbstractRepository):
         Args:
             session (Session): The SQLAlchemy session to use.
         """
-        super().__init__()
-        self.session: Session = session
-        self._check_connection()
+        super().__init__(session, User)
 
-    def _check_connection(self) -> None:
-        """Check the database connection.
-
-        Raises:
-            DBCannotBeConnectedError: If the database connection cannot be
-                established.
-        """
-        try:
-            self.session.connection()
-        except OperationalError:
-            raise DBCannotBeConnectedError(message="Can't connect to Database")
-
-    def _add(self, user: User) -> None:
-        """Add a user to the database.
-
-        Args:
-            user (User): The user entity to add.
-        """
-        self.session.add(user)
-
-    def _get(self, user_id: UUID) -> User:
-        """Retrieve a user by ID from the database.
-
-        Args:
-            user_id (UUID): The ID of the user to retrieve.
-
-        Returns:
-            User: The user entity with the specified ID.
-        """
-        return self.session.query(User).filter_by(id=user_id).one()
-
-    def _get_by_name(self, username: str) -> User:
+    def get_by_name(self, username: str) -> User:
         """Retrieve a user by username from the database.
 
         Args:
@@ -233,19 +73,3 @@ class SqlAlchemyRepository(AbstractRepository):
             User: The user entity with the specified username.
         """
         return self.session.query(User).filter_by(username=username).one()
-
-    def _get_all(self) -> List[User]:
-        """Retrieve a list of users from the database.
-
-        Returns:
-            List[User]: List of all user entities in the database.
-        """
-        return self.session.query(User).all()
-
-    def _delete(self, user_id: UUID) -> None:
-        """Delete a user by ID from the database.
-
-        Args:
-            user_id (UUID): The ID of the user to delete.
-        """
-        self.session.query(User).filter_by(id=user_id).delete()

--- a/openvair/modules/user/adapters/repository.py
+++ b/openvair/modules/user/adapters/repository.py
@@ -1,29 +1,11 @@
-"""Repository layer for user management.
+"""SQLAlchemy repository for the user module.
 
-This module defines the abstract and concrete repository implementations
-for managing user entities. It includes methods for adding, retrieving,
-and deleting users from the database.
+This module implements the repository pattern to manage User entities
+in the database using SQLAlchemy.
 
 Classes:
-    AbstractRepository: Abstract base class for user repository operations.
-    SqlAlchemyRepository: Concrete implementation of AbstractRepository
-        using SQLAlchemy for database operations.
-
-Exceptions:
-    DBCannotBeConnectedError: Custom exception raised when the database
-        connection fails.
-
-Methods:
-    AbstractRepository._check_connection: Abstract method for checking
-        database connection.
-    SqlAlchemyRepository._check_connection: Checks the database connection
-        and raises an exception if the connection fails.
-    SqlAlchemyRepository._add: Adds a user to the database.
-    SqlAlchemyRepository._get: Retrieves a user by ID from the database.
-    SqlAlchemyRepository._get_by_name: Retrieves a user by username from
-        the database.
-    SqlAlchemyRepository._get_all: Retrieves a list of users from the database.
-    SqlAlchemyRepository._delete: Deletes a user by ID from the database.
+    UserSqlAlchemyRepository: Class for database operations. Concrete
+        implementation of BaseSqlAlchemyRepository.
 """
 
 from typing import TYPE_CHECKING
@@ -36,27 +18,15 @@ from openvair.common.repositories.base_sqlalchemy import (
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
-class SqlAlchemyRepository(BaseSqlAlchemyRepository[User]):
-    """Concrete implementation of AbstractRepository using SQLAlchemy.
-
-    This class provides the actual implementation of repository methods
-    using SQLAlchemy ORM for database operations.
+class UserSqlAlchemyRepository(BaseSqlAlchemyRepository[User]):
+    """Repository for managing user entities.
 
     Args:
         session (Session): The SQLAlchemy session to use for database operations
-
-    Methods:
-        _check_connection: Checks the database connection and raises an
-            exception if the connection fails.
-        _add: Adds a user to the database.
-        _get: Retrieves a user by ID from the database.
-        _get_by_name: Retrieves a user by username from the database.
-        _get_all: Retrieves a list of users from the database.
-        _delete: Deletes a user by ID from the database.
     """
 
     def __init__(self, session: 'Session'):
-        """Initialize the SqlAlchemyRepository with a session.
+        """Initialize the UserSqlAlchemyRepository with a session.
 
         Args:
             session (Session): The SQLAlchemy session to use.

--- a/openvair/modules/user/service_layer/services.py
+++ b/openvair/modules/user/service_layer/services.py
@@ -46,6 +46,9 @@ class UserManager(BackgroundTasks):
     coordinating interactions between the API layer, domain layer, and database.
     It handles tasks such as user authentication, creation, deletion, and
     password management.
+
+    Attributes:
+        uow (UserSqlAlchemyUnitOfWork): Unit of Work for user transactions.
     """
 
     def __init__(self) -> None:
@@ -54,7 +57,7 @@ class UserManager(BackgroundTasks):
         This constructor sets up the necessary components for the UserManager,
         including:
         - Initializing the parent BackgroundTasks class
-        - Setting up the unit of work for database operations
+        - Declaring the unit of work class for database operations.
         """
         super().__init__()
         self.uow = unit_of_work.UserSqlAlchemyUnitOfWork

--- a/openvair/modules/user/service_layer/services.py
+++ b/openvair/modules/user/service_layer/services.py
@@ -57,7 +57,7 @@ class UserManager(BackgroundTasks):
         - Setting up the unit of work for database operations
         """
         super().__init__()
-        self.uow = unit_of_work.SqlAlchemyUnitOfWork()
+        self.uow = unit_of_work.UserSqlAlchemyUnitOfWork
 
     @staticmethod
     def _hash_password(password: str) -> str:
@@ -102,8 +102,8 @@ class UserManager(BackgroundTasks):
         """
         LOG.info('Start getting user by id from DB.')
         user_id = data.get('user_id', '')
-        with self.uow:
-            user: User = self.uow.users.get(user_id)
+        with self.uow() as uow:
+            user: User = uow.users.get_or_fail(user_id)
             return DataSerializer.to_web(user)
 
     def get_all_users(self) -> List:
@@ -113,8 +113,8 @@ class UserManager(BackgroundTasks):
             List: List of serialized user data for each user.
         """
         LOG.info('Start getting all users from DB')
-        with self.uow:
-            users = self.uow.users.get_all()
+        with self.uow() as uow:
+            users = uow.users.get_all()
             return [DataSerializer.to_web(user) for user in users]
 
     def authenticate_user(self, data: Dict) -> Dict:
@@ -134,8 +134,8 @@ class UserManager(BackgroundTasks):
         username: str = data.get('username', '')
         password: str = data.get('password', '')
 
-        with self.uow:
-            db_user: User = self.uow.users.get_by_name(username)
+        with self.uow() as uow:
+            db_user: User = uow.users.get_by_name(username)
 
             if not self._verify_password(password, db_user.hashed_password):
                 message = 'Wrong credentials'
@@ -213,11 +213,11 @@ class UserManager(BackgroundTasks):
         self._check_is_super_user(data)
         self._verificate_user_id(data)
         user_info: UserInfo = self._prepare_user_info(data)
-        with self.uow:
+        with self.uow() as uow:
             db_user: User = DataSerializer.to_db(user_info._asdict())
             try:
-                self.uow.users.add(db_user)
-                self.uow.commit()
+                uow.users.add(db_user)
+                uow.commit()
                 LOG.info('User was successfully created.')
             except exc.IntegrityError as _:
                 message = (
@@ -251,16 +251,16 @@ class UserManager(BackgroundTasks):
             message = 'Got empty new password.'
             LOG.error(message)
             raise exceptions.UnexpectedData(message)
-        with self.uow:
+        with self.uow() as uow:
             try:
-                db_user: User = self.uow.users.get(user_id)
+                db_user: User = uow.users.get_or_fail(user_id)
                 db_user.hashed_password = self._hash_password(new_password)
             except exc.NoResultFound as _:
                 message = f"User with current id {user_id} doesn't exist."
                 LOG.error(message)
                 raise exceptions.UserDoesNotExist(message)
             finally:
-                self.uow.commit()
+                uow.commit()
         return DataSerializer.to_web(db_user)
 
     def delete_user(self, data: Dict) -> Dict:
@@ -278,16 +278,16 @@ class UserManager(BackgroundTasks):
         LOG.info('Start deleting user from db.')
         self._verificate_user_id(data)
         user_id = data.get('user_id', '')
-        with self.uow:
+        with self.uow() as uow:
             try:
-                self.uow.users.get(user_id)
-                self.uow.users.delete(user_id)
+                uow.users.get_or_fail(user_id)
+                uow.users.delete_by_id(user_id)
             except exc.NoResultFound as _:
                 message = f"User with current id {user_id} doesn't exist."
                 LOG.error(message)
                 raise exceptions.UserDoesNotExist(message)
             finally:
-                self.uow.commit()
+                uow.commit()
             LOG.info('User deleted successfully')
 
         return {'id': user_id, 'message': 'User was successfully deleted'}

--- a/openvair/modules/user/service_layer/unit_of_work.py
+++ b/openvair/modules/user/service_layer/unit_of_work.py
@@ -1,14 +1,10 @@
 """Unit of Work pattern implementation for user management.
 
-This module defines an abstract base class and a SQLAlchemy-based concrete
-implementation of the Unit of Work pattern. The Unit of Work pattern helps
-manage database transactions and ensures that all operations within a
-transaction are completed successfully before committing.
+This module defines a SQLAlchemy-based Unit of Work for managing database
+transactions and repositories.
 
 Classes:
-    AbstractUnitOfWork: Abstract base class defining the Unit of Work interface.
-    SqlAlchemyUnitOfWork: Concrete implementation of the Unit of Work interface
-        using SQLAlchemy for database transactions.
+    UserSqlAlchemyUnitOfWork: Unit of Work for the User module.
 """
 
 from __future__ import annotations
@@ -23,22 +19,25 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import sessionmaker
 
 class UserSqlAlchemyUnitOfWork(BaseSqlAlchemyUnitOfWork):
-    """SQLAlchemy-based implementation of the Unit of Work pattern.
+    """Unit of Work for User module.
 
-    This class manages database transactions using SQLAlchemy and provides
-    concrete implementations of the methods defined in AbstractUnitOfWork.
+    This class manages database transactions for users, ensuring consistency
+    by committing or rolling back operations.
+
+    Attributes:
+        users (UserSqlAlchemyRepository): Repository for user entities.
     """
 
     def __init__(self, session_factory: sessionmaker = DEFAULT_SESSION_FACTORY):
-        """Initialize the SqlAlchemyUnitOfWork with a session factory.
+        """Initialize the Unit of Work with a session factory.
 
         Args:
             session_factory (sessionmaker): The SQLAlchemy session factory to
-                use.
+                use. Defaults to DEFAULT_SESSION_FACTORY.
         """
         super().__init__(session_factory)
 
     def _init_repositories(self) -> None:
-        """Initializes repositories for the template module."""
-        self.users = repository.SqlAlchemyRepository(self.session)
+        """Initializes repositories for the user module."""
+        self.users = repository.UserSqlAlchemyRepository(self.session)
 

--- a/openvair/modules/user/service_layer/unit_of_work.py
+++ b/openvair/modules/user/service_layer/unit_of_work.py
@@ -13,54 +13,16 @@ Classes:
 
 from __future__ import annotations
 
-import abc
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from openvair.modules.user.config import DEFAULT_SESSION_FACTORY
 from openvair.modules.user.adapters import repository
+from openvair.common.uow.base_sqlalchemy import BaseSqlAlchemyUnitOfWork
 
 if TYPE_CHECKING:
-    from sqlalchemy.orm import Session, sessionmaker
+    from sqlalchemy.orm import sessionmaker
 
-
-class AbstractUnitOfWork(metaclass=abc.ABCMeta):
-    """Abstract base class for the Unit of Work pattern.
-
-    This class defines the interface for managing database transactions
-    within a unit of work. Subclasses must implement the methods for
-    committing, rolling back, and entering/exiting the unit of work.
-    """
-
-    users: repository.AbstractRepository
-
-    def __enter__(self) -> AbstractUnitOfWork:
-        """Enter the runtime context related to this object.
-
-        Returns:
-            AbstractUnitOfWork: The instance of the Unit of Work.
-        """
-        return self
-
-    def __exit__(self, *args: Any) -> None: # noqa: ANN401 # TODO need to parameterize the arguments correctly, in accordance with static typing
-        """Exit the runtime context and rollback if necessary.
-
-        Args:
-            *args: Variable length argument list for context exit handling.
-        """
-        self.rollback()
-
-    @abc.abstractmethod
-    def commit(self) -> None:
-        """Commit the transaction."""
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def rollback(self) -> None:
-        """Rollback the transaction."""
-        raise NotImplementedError
-
-
-class SqlAlchemyUnitOfWork(AbstractUnitOfWork):
+class UserSqlAlchemyUnitOfWork(BaseSqlAlchemyUnitOfWork):
     """SQLAlchemy-based implementation of the Unit of Work pattern.
 
     This class manages database transactions using SQLAlchemy and provides
@@ -74,39 +36,9 @@ class SqlAlchemyUnitOfWork(AbstractUnitOfWork):
             session_factory (sessionmaker): The SQLAlchemy session factory to
                 use.
         """
-        self.session_factory = session_factory
-        self.session: Session
+        super().__init__(session_factory)
 
-    def __enter__(self) -> AbstractUnitOfWork:
-        """Enter the runtime context related to this object.
-
-        This method initializes the SQLAlchemy session and repository, and
-        returns the instance of the Unit of Work.
-
-        Returns:
-            SqlAlchemyUnitOfWork: The instance of the Unit of Work.
-        """
-        self.session = self.session_factory()
+    def _init_repositories(self) -> None:
+        """Initializes repositories for the template module."""
         self.users = repository.SqlAlchemyRepository(self.session)
-        return super().__enter__()
 
-    def __exit__(self, *args: Any) -> None: # noqa: ANN401 # TODO need to parameterize the arguments correctly, in accordance with static typing
-        """Exit the runtime context and close the session.
-
-        This method ensures that the session is closed after the transaction
-        is complete, and it calls the parent class's __exit__ method to
-        handle any necessary rollback.
-
-        Args:
-            *args: Variable length argument list for context exit handling.
-        """
-        super().__exit__(*args)
-        self.session.close()
-
-    def commit(self) -> None:
-        """Commit the current transaction."""
-        self.session.commit()
-
-    def rollback(self) -> None:
-        """Rollback the current transaction."""
-        self.session.rollback()


### PR DESCRIPTION
# Описание изменений

Перевод Unit of Work и repository модуля User на использование базовых общих абстракций BaseSqlAlchemyRepository и BaseSqlAlchemyUnitOfWork

# Ключевые изменения

- Удалены абстрактные классы AbstractUnitOfWork и AbstractRepository, от которых наследовались repository и unit_of_work
- Удалены методы, дублирующие логику абстрактных классов BaseSqlAlchemyRepository и BaseSqlAlchemyUnitOfWork
- Изменена инициализация uow и его использование в контекстном менеджере with
- Обновлён UserManager, так чтобы он использовал новый uow

