### PR TITLE
Рефакторинг uow и repository в модуле notification

### DIFF
--- a/openvair/modules/notification/adapters/repository.py
+++ b/openvair/modules/notification/adapters/repository.py
@@ -1,8 +1,7 @@
 """Repository pattern implementation for notifications.
 
-This module defines abstract and concrete repositories for managing
-notifications in the database. It includes functionality for adding, retrieving,
-updating, and deleting notifications.
+This module implements the repository pattern to manage Notification entities
+in the database using SQLAlchemy.
 """
 
 from typing import TYPE_CHECKING, Dict, List, Optional, cast
@@ -21,7 +20,7 @@ class NotificationSqlAlchemyRepository(BaseSqlAlchemyRepository[Notification]):
     """SQLAlchemy-based implementation of the notification repository."""
 
     def __init__(self, session: 'Session'):
-        """Initialize the SqlAlchemyRepository.
+        """Repository for managing Notification entities.
 
         Args:
             session (Session): The SQLAlchemy session to use for database
@@ -38,7 +37,8 @@ class NotificationSqlAlchemyRepository(BaseSqlAlchemyRepository[Notification]):
             notifications_type (str): The type of notifications to retrieve.
 
         Returns:
-            List[Notification]: A list of notifications of the specified type.
+            Optional[Notification]: A list of notifications of the specified
+            type or None.
         """
         return (
             self.session.query(Notification)
@@ -56,8 +56,8 @@ class NotificationSqlAlchemyRepository(BaseSqlAlchemyRepository[Notification]):
                 retrieve.
 
         Returns:
-            List[Notification]: A list of notifications with the specified
-                subject.
+            Optional[Notification]: A list of notifications with the specified
+                subject or None.
         """
         return (
             self.session.query(Notification)

--- a/openvair/modules/notification/adapters/repository.py
+++ b/openvair/modules/notification/adapters/repository.py
@@ -5,184 +5,19 @@ notifications in the database. It includes functionality for adding, retrieving,
 updating, and deleting notifications.
 """
 
-import abc
-from uuid import UUID
 from typing import TYPE_CHECKING, Dict, List, Optional, cast
 
-from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm.mapper import Mapper
 
-from openvair.abstracts.exceptions import DBCannotBeConnectedError
 from openvair.modules.notification.adapters.orm import Notification
+from openvair.common.repositories.base_sqlalchemy import (
+    BaseSqlAlchemyRepository,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
-
-class AbstractRepository(metaclass=abc.ABCMeta):
-    """Abstract base class for notification repositories."""
-
-    def _check_connection(self) -> None:
-        """Check the database connection.
-
-        Raises:
-            NotImplementedError: If the method is not implemented.
-        """
-        raise NotImplementedError
-
-    def add(self, notification: Notification) -> None:
-        """Add a notification to the repository.
-
-        Args:
-            notification (Notification): The notification to add.
-        """
-        self._add(notification)
-
-    def get(self, notification_id: UUID) -> Notification:
-        """Retrieve a notification by its ID.
-
-        Args:
-            notification_id (UUID): The ID of the notification to retrieve.
-
-        Returns:
-            Notification: The retrieved notification.
-        """
-        return self._get(notification_id)
-
-    def get_all(self) -> List[Notification]:
-        """Retrieve all notifications.
-
-        Returns:
-            List[Notification]: A list of all notifications.
-        """
-        return self._get_all()
-
-    def get_notifications_by_type(
-        self, notifications_type: str
-    ) -> Optional[Notification]:
-        """Retrieve notifications by their type.
-
-        Args:
-            notifications_type (str): The type of notifications to retrieve.
-
-        Returns:
-            List[Notification]: A list of notifications of the specified type.
-        """
-        return self._get_notifications_by_type(notifications_type)
-
-    def get_notifications_by_subject(
-        self, notifications_subject: str
-    ) -> Optional[Notification]:
-        """Retrieve notifications by their subject.
-
-        Args:
-            notifications_subject (str): The subject of notifications to
-                retrieve.
-
-        Returns:
-            List[Notification]: A list of notifications with the specified
-                subject.
-        """
-        return self._get_notifications_by_subject(notifications_subject)
-
-    def delete(self, notification_id: UUID) -> None:
-        """Delete a notification by its ID.
-
-        Args:
-            notification_id (UUID): The ID of the notification to delete.
-        """
-        return self._delete(notification_id)
-
-    def bulk_update(self, data: List[Dict]) -> None:
-        """Perform a bulk update on notifications.
-
-        Args:
-            data (List[Dict]): A list of dictionaries containing the updated
-                notification data.
-        """
-        self._bulk_update(data)
-
-    @abc.abstractmethod
-    def _add(self, notification: Notification) -> None:
-        """Add a notification to the repository.
-
-        Args:
-            notification (Notification): The notification to add.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _get(self, notification_id: UUID) -> Notification:
-        """Retrieve a notification by its ID.
-
-        Args:
-            notification_id (UUID): The ID of the notification to retrieve.
-
-        Returns:
-            Notification: The retrieved notification.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _get_all(self) -> List[Notification]:
-        """Retrieve all notifications.
-
-        Returns:
-            List[Notification]: A list of all notifications.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _get_notifications_by_type(
-        self, notifications_type: str
-    ) -> Optional[Notification]:
-        """Retrieve notifications by their type.
-
-        Args:
-            notifications_type (str): The type of notifications to retrieve.
-
-        Returns:
-            List[Notification]: A list of notifications of the specified type.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _get_notifications_by_subject(
-        self, notification_subject: str
-    ) -> Optional[Notification]:
-        """Retrieve notifications by their subject.
-
-        Args:
-            notification_subject (str): The subject of notifications to
-                retrieve.
-
-        Returns:
-            List[Notification]: A list of notifications with the specified
-                subject.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _delete(self, notification_id: UUID) -> None:
-        """Delete a notification by its ID.
-
-        Args:
-            notification_id (UUID): The ID of the notification to delete.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _bulk_update(self, data: List[Dict]) -> None:
-        """Perform a bulk update on notifications.
-
-        Args:
-            data (List[Dict]): A list of dictionaries containing the updated
-                notification data.
-        """
-        raise NotImplementedError
-
-
-class SqlAlchemyRepository(AbstractRepository):
+class NotificationSqlAlchemyRepository(BaseSqlAlchemyRepository[Notification]):
     """SQLAlchemy-based implementation of the notification repository."""
 
     def __init__(self, session: 'Session'):
@@ -192,50 +27,7 @@ class SqlAlchemyRepository(AbstractRepository):
             session (Session): The SQLAlchemy session to use for database
                 operations.
         """
-        super().__init__()
-        self.session: Session = session
-        self._check_connection()
-
-    def _check_connection(self) -> None:
-        """Check the database connection.
-
-        Raises:
-            DBCannotBeConnectedError: If the database connection cannot be
-                established.
-        """
-        try:
-            self.session.connection()
-        except OperationalError:
-            raise DBCannotBeConnectedError(message="Can't connect to Database")
-
-    def _add(self, notification: Notification) -> None:
-        """Add a notification to the repository.
-
-        Args:
-            notification (Notification): The notification to add.
-        """
-        self.session.add(notification)
-
-    def _get(self, notification_id: UUID) -> Notification:
-        """Retrieve a notification by its ID.
-
-        Args:
-            notification_id (UUID): The ID of the notification to retrieve.
-
-        Returns:
-            Notification: The retrieved notification.
-        """
-        return (
-            self.session.query(Notification).filter_by(id=notification_id).one()
-        )
-
-    def _get_all(self) -> List[Notification]:
-        """Retrieve all notifications.
-
-        Returns:
-            List[Notification]: A list of all notifications.
-        """
-        return self.session.query(Notification).all()
+        super().__init__(session, Notification)
 
     def _get_notifications_by_type(
         self, notifications_type: str
@@ -272,14 +64,6 @@ class SqlAlchemyRepository(AbstractRepository):
             .filter_by(name=notification_subject)
             .first()
         )
-
-    def _delete(self, notification_id: UUID) -> None:
-        """Delete a notification by its ID.
-
-        Args:
-            notification_id (UUID): The ID of the notification to delete.
-        """
-        self.session.query(Notification).filter_by(id=notification_id).delete()
 
     def _bulk_update(self, data: List[Dict]) -> None:
         """Perform a bulk update on notifications.

--- a/openvair/modules/notification/service_layer/services.py
+++ b/openvair/modules/notification/service_layer/services.py
@@ -56,8 +56,8 @@ class NotificationServiceLayerManager(BackgroundTasks):
     the domain layer and manages database transactions.
 
     Attributes:
-        uow (SqlAlchemyUnitOfWork): The unit of work for managing database
-            transactions.
+        uow (NotificationSqlAlchemyUnitOfWork): The unit of work for managing
+            database transactions.
         domain_rpc (Protocol): The RPC client for interacting with the domain
             layer.
         service_layer_rpc (Protocol): The RPC client for interacting with the
@@ -71,7 +71,7 @@ class NotificationServiceLayerManager(BackgroundTasks):
         interacting with the domain layer and service layer queues.
         """
         super().__init__()
-        self.uow = unit_of_work.SqlAlchemyUnitOfWork()
+        self.uow = unit_of_work.NotificationSqlAlchemyUnitOfWork
         self.domain_rpc = MessagingClient(
             queue_name=SERVICE_LAYER_DOMAIN_QUEUE_NAME
         )
@@ -147,9 +147,9 @@ class NotificationServiceLayerManager(BackgroundTasks):
         LOG.info('Handling call on write notification.')
         notification.status = status.name
         notification.create_datetime = datetime.datetime.now()
-        with self.uow:
-            self.uow.notifications.add(notification)
-            self.uow.commit()
+        with self.uow() as uow:
+            uow.notifications.add(notification)
+            uow.commit()
 
         LOG.info(
             'Handling call on write notification was successfully processed.'

--- a/openvair/modules/notification/service_layer/services.py
+++ b/openvair/modules/notification/service_layer/services.py
@@ -67,7 +67,7 @@ class NotificationServiceLayerManager(BackgroundTasks):
     def __init__(self) -> None:
         """Initialize the NotificationServiceLayerManager.
 
-        This constructor sets up the unit of work and RPC protocols for
+        This constructor declares the unit of work and sets up RPC protocols for
         interacting with the domain layer and service layer queues.
         """
         super().__init__()

--- a/openvair/modules/notification/service_layer/unit_of_work.py
+++ b/openvair/modules/notification/service_layer/unit_of_work.py
@@ -27,7 +27,7 @@ class NotificationSqlAlchemyUnitOfWork(BaseSqlAlchemyUnitOfWork):
 
     Attributes:
         notifications (NotificationSqlAlchemyRepository): Repository for
-            notification entities.
+            Notification entities.
     """
 
     def __init__(self, session_factory: sessionmaker = DEFAULT_SESSION_FACTORY):

--- a/openvair/modules/notification/service_layer/unit_of_work.py
+++ b/openvair/modules/notification/service_layer/unit_of_work.py
@@ -1,102 +1,44 @@
 """Unit of Work pattern for the notification service layer.
 
-This module provides the `AbstractUnitOfWork` and `SqlAlchemyUnitOfWork`
-classes, which implement the Unit of Work pattern for managing database
+This module provides SQLAlchemy-based Unit of Work for managing database
 transactions in the notification service layer.
 
 Classes:
-    - AbstractUnitOfWork: Abstract base class for the Unit of Work pattern.
-    - SqlAlchemyUnitOfWork: Concrete implementation of the Unit of Work pattern
-        using SQLAlchemy.
+    - NotificationSqlAlchemyUnitOfWork: Unit of Work for the notification
+        module.
 """
 
 from __future__ import annotations
 
-import abc
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from typing_extensions import Self
-
+from openvair.common.uow.base_sqlalchemy import BaseSqlAlchemyUnitOfWork
 from openvair.modules.notification.config import DEFAULT_SESSION_FACTORY
 from openvair.modules.notification.adapters import repository
 
 if TYPE_CHECKING:
-    from sqlalchemy.orm import Session, sessionmaker
+    from sqlalchemy.orm import sessionmaker
 
+class NotificationSqlAlchemyUnitOfWork(BaseSqlAlchemyUnitOfWork):
+    """Unit of Work for the notification module.
 
-class AbstractUnitOfWork(metaclass=abc.ABCMeta):
-    """Abstract base class for the Unit of Work pattern."""
+    This class manages database transactions for notifications, ensuring
+    consistency by committing or rolling back operations.
 
-    notifications: repository.AbstractRepository
-
-    @abc.abstractmethod
-    def __enter__(self) -> AbstractUnitOfWork:
-        """Enter the runtime context related to this object.
-
-        Returns:
-            AbstractUnitOfWork: The unit of work instance.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def __exit__(self, *args: Any) -> None:  # noqa: ANN401 # TODO need to parameterize the arguments correctly, in accordance with static typing
-        """Exit the runtime context related to this object.
-
-        This method is responsible for rolling back the transaction if an
-        exception occurs.
-        """
-        self.rollback()
-
-    @abc.abstractmethod
-    def commit(self) -> None:
-        """Commit the transaction."""
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def rollback(self) -> None:
-        """Rollback the transaction."""
-        raise NotImplementedError
-
-
-class SqlAlchemyUnitOfWork(AbstractUnitOfWork):
-    """SQLAlchemy-based implementation of the Unit of Work pattern."""
+    Attributes:
+        notifications (NotificationSqlAlchemyRepository): Repository for
+            notification entities.
+    """
 
     def __init__(self, session_factory: sessionmaker = DEFAULT_SESSION_FACTORY):
-        """Initialize the SqlAlchemyUnitOfWork.
+        """Initializes the Unit of Work with a session factory.
 
         Args:
             session_factory (sessionmaker): The session factory to use for
                 creating sessions. Defaults to DEFAULT_SESSION_FACTORY.
         """
-        self.session_factory = session_factory
-        self.session: Session
+        super().__init__(session_factory)
 
-    def __enter__(self) -> Self:
-        """Enter the runtime context related to this object.
-
-        This method creates a new session and sets up the notifications
-        repository.
-
-        Returns:
-            SqlAlchemyUnitOfWork: The unit of work instance.
-        """
-        self.session = self.session_factory()
+    def _init_repositories(self) -> None:
+        """Initializes repositories for the notification module."""
         self.notifications = repository.SqlAlchemyRepository(self.session)
-        return self
-
-    def __exit__(self, *args: Any) -> None:  # noqa: ANN401 # TODO need to parameterize the arguments correctly, in accordance with static typing
-        """Exit the runtime context related to this object.
-
-        This method closes the session and handles any exceptions by rolling
-        back the transaction.
-        """
-        super().__exit__(args)
-        self.session.close()
-
-    def commit(self) -> None:
-        """Commit the transaction."""
-        self.session.commit()
-
-    def rollback(self) -> None:
-        """Rollback the transaction."""
-        self.session.rollback()

--- a/openvair/modules/notification/service_layer/unit_of_work.py
+++ b/openvair/modules/notification/service_layer/unit_of_work.py
@@ -41,4 +41,6 @@ class NotificationSqlAlchemyUnitOfWork(BaseSqlAlchemyUnitOfWork):
 
     def _init_repositories(self) -> None:
         """Initializes repositories for the notification module."""
-        self.notifications = repository.SqlAlchemyRepository(self.session)
+        self.notifications = repository.NotificationSqlAlchemyRepository(
+            self.session
+        )


### PR DESCRIPTION
# Описание изменений

Перевод Unit of Work и repository модуля notification на использование базовых общих абстракций BaseSqlAlchemyRepository и BaseSqlAlchemyUnitOfWork

# Ключевые изменения

- Удалены абстрактные классы AbstractUnitOfWork и AbstractRepository, от которых наследовались repository и unit_of_work
- Удалены методы, дублирующие логику абстрактных классов BaseSqlAlchemyRepository и BaseSqlAlchemyUnitOfWork
- Изменена инициализация uow и его использование в контекстном менеджере with в файле service.py
- Обновлён NotificationServiceLayerManager, так чтобы он использовал новый uow