### PR TITLE
Рефакторинг uow, repository модуля block_device

### DIFF
--- a/openvair/modules/block_device/adapters/repository.py
+++ b/openvair/modules/block_device/adapters/repository.py
@@ -1,150 +1,44 @@
-"""This module contains classes that implement the repository pattern.
+"""SQLAlchemy repository for the block_device module.
 
-It includes an abstract base class `AbstractRepository` which defines
-the interface for managing ISCSIInterface objects, and a concrete implementation
-`SqlAlchemyRepository` which provides methods for accessing and manipulating
-these objects in a SQLAlchemy database.
-
-Classes:
-    AbstractRepository: Abstract base class for the repository pattern.
-    SqlAlchemyRepository: Concrete implementation of AbstractRepository
-        using SQLAlchemy.
+This module implements the repository pattern to manage ISCSIInterface entities
+in the database using SQLAlchemy.
 """
 
-import abc
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
-from sqlalchemy.exc import OperationalError
-
-from openvair.abstracts.exceptions import DBCannotBeConnectedError
 from openvair.modules.block_device.adapters.orm import ISCSIInterface
+from openvair.common.repositories.base_sqlalchemy import (
+    BaseSqlAlchemyRepository,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
+class BlockDeviceSqlAlchemyRepository(BaseSqlAlchemyRepository[ISCSIInterface]):
+    """Repository for managing ISCSIInterface entities.
 
-class AbstractRepository(metaclass=abc.ABCMeta):
-    """Implements the abstract repository pattern"""
-
-    def _check_connection(self) -> None:
-        """Check if the database is connected
-
-        Raises:
-            NotImplementedError: if the method called for abstract class
-                instance
-        """
-        raise NotImplementedError
-
-    # ISCSIInterface
-    def add(self, interface: ISCSIInterface) -> None:
-        """Abstract public method to add a new ISCSI interface
-
-        Args:
-            interface (ISCSIInterface): orm object of the ISCSCI interface
-        """
-        self._add(interface)
-
-    def get(self, interface_id: str) -> ISCSIInterface:
-        """Abstract public method to get an ISCSI interface by id
-
-        Args:
-            interface_id (str): database id of the ISCSCI interface
-
-        Returns:
-            ISCSIInterface: orm object of the ISCSI interface
-        """
-        return self._get(interface_id)
-
-    def get_by_ip(self, interface_ip: str) -> ISCSIInterface:
-        """Abstract public method to get an ISCSI interface by ip
-
-        Args:
-            interface_ip (str): ip address of the ISCSCI interface
-
-        Returns:
-            ISCSIInterface: orm object of the ISCSI interface
-        """
-        return self._get_by_ip(interface_ip)
-
-    def get_all(self) -> List:
-        """Abstract public method to get all ISCSI interfaces
-
-        Returns:
-            List: List of orm objects of the ISCSI interfaces
-        """
-        return self._get_all()
-
-    def delete(self, interface_id: str) -> None:
-        """Abstract public method to delete an ISCSI interface
-
-        Args:
-            interface_id (str): database ID of the ISCSI interface to delete
-        """
-        self._delete(interface_id)
-
-    @abc.abstractmethod
-    def _add(self, interface: ISCSIInterface) -> None:
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _get(self, interface_id: str) -> ISCSIInterface:
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _get_by_ip(self, interface_ip: str) -> ISCSIInterface:
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _get_all(self) -> List:
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def _delete(self, interface_id: str) -> None:
-        raise NotImplementedError
-
-
-class SqlAlchemyRepository(AbstractRepository):
-    """Implementation of the AbstractRepository for the block device module
-
-    That class provides methods for accessing to database tables for
-    manipulating data of the block device module.
-
-    Args:
-        AbstractRepository (_type_): _description_
+    This class provides CRUD operations for the block_device model using
+    SQLAlchemy.
     """
 
     def __init__(self, session: 'Session'):
-        """Create a new instance of SqlAlchemyRepository
+        """Initializes the repository with a database session.
 
         Args:
             session (Session): SQLAlchemy session for accessing the database
                 tables
         """
-        super(SqlAlchemyRepository, self).__init__()
-        self.session: 'Session' = session
-        self._check_connection()
+        super().__init__(session, ISCSIInterface)
 
-    def _check_connection(self) -> None:
-        try:
-            self.session.connection()
-        except OperationalError:
-            raise DBCannotBeConnectedError(message="Can't connect to Database")
+    def get_by_ip(self, interface_ip: str) -> ISCSIInterface:
+        """Retrieve a ISCSIInterface by its ip.
 
-    def _add(self, interface: ISCSIInterface) -> None:
-        self.session.add(interface)
+        Args:
+            interface_ip (str): The ip of the ISCSIInterface to fetch.
 
-    def _get(self, interface_id: str) -> ISCSIInterface:
-        return (
-            self.session.query(ISCSIInterface).filter_by(id=interface_id).one()
-        )
-
-    def _get_by_ip(self, interface_ip: str) -> ISCSIInterface:
+        Returns:
+            ISCSIInterface: The ISCSIInterface instance from the database.
+        """
         return (
             self.session.query(ISCSIInterface).filter_by(ip=interface_ip).one()
         )
-
-    def _get_all(self) -> List[ISCSIInterface]:
-        return self.session.query(ISCSIInterface).all()
-
-    def _delete(self, interface_id: str) -> None:
-        self.session.query(ISCSIInterface).filter_by(id=interface_id).delete()

--- a/openvair/modules/block_device/service_layer/unit_of_work.py
+++ b/openvair/modules/block_device/service_layer/unit_of_work.py
@@ -1,113 +1,45 @@
-"""Module for managing the UnitOfWork pattern in the Block Device service layer.
+"""Unit of Work implementation for the block_device module.
 
-This module defines the `AbstractUnitOfWork` abstract base class, which provides
-a common interface for managing database transactions and repository
-interactions. The `SqlAlchemyUnitOfWork` class is a concrete implementation of
-the `AbstractUnitOfWork` class, which uses SQLAlchemy to handle the database
-operations.
-
-The `AbstractUnitOfWork` class defines the following methods:
-- `__enter__`: Enters the unit of work context, initializing the repository.
-- `__exit__`: Exits the unit of work context, performing a rollback if
-    necessary.
-- `commit`: Commits the current database transaction.
-- `rollback`: Rolls back the current database transaction.
-
-The `SqlAlchemyUnitOfWork` class is a subclass of `AbstractUnitOfWork` that
-provides the concrete implementation of the unit of work using SQLAlchemy.
+This module defines a SQLAlchemy-based Unit of Work for managing
+interface-related transactions and repositories.
 
 Classes:
-    AbstractUnitOfWork: Abstract base class for managing the Unit of Work
-        pattern.
-    SqlAlchemyUnitOfWork: Concrete implementation of the Unit of Work pattern
-        using SQLAlchemy.
+    BlockDeviceSqlAlchemyUnitOfWork: Unit of Work for the block_device module.
 """
 
 from __future__ import annotations
 
-import abc
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
+from openvair.common.uow.base_sqlalchemy import BaseSqlAlchemyUnitOfWork
 from openvair.modules.block_device.config import DEFAULT_SESSION_FACTORY
 from openvair.modules.block_device.adapters import repository
 
 if TYPE_CHECKING:
-    from sqlalchemy.orm import Session, sessionmaker
+    from sqlalchemy.orm import sessionmaker
 
+class BlockDeviceSqlAlchemyUnitOfWork(BaseSqlAlchemyUnitOfWork):
+    """Unit of Work for the block_device module.
 
-class AbstractUnitOfWork(metaclass=abc.ABCMeta):
-    """Abstract base class for managing the Unit of Work pattern.
-
-    This class defines the common interface for managing database transactions
-    and repository interactions. Concrete implementations of this class should
-    provide the specific implementation details for their respective data
-    storage solutions.
+    This class manages database transactions for interfaces, ensuring
+    consistency by committing or rolling back operations.
 
     Attributes:
-        interfaces (repository.AbstractRepository): The repository interface for
-            interacting with the underlying data storage.
-    """
-
-    interfaces: repository.AbstractRepository
-
-    def __enter__(self) -> AbstractUnitOfWork:
-        """Enter the unit of work context, initializing the repository."""
-        return self
-
-    def __exit__(self, *args: Any) -> None:  # noqa: ANN401 # TODO need to parameterize the arguments correctly, in accordance with static typing
-        """Exit the unit of work context, performing a rollback if necessary."""
-        self.rollback()
-
-    @abc.abstractmethod
-    def commit(self) -> None:
-        """Commit the current database transaction."""
-        pass
-
-    @abc.abstractmethod
-    def rollback(self) -> None:
-        """Roll back the current database transaction."""
-        pass
-
-
-class SqlAlchemyUnitOfWork(AbstractUnitOfWork):
-    """Concrete implementation of the Unit of Work pattern using SQLAlchemy.
-
-    This class provides the implementation of the Unit of Work pattern using
-    SQLAlchemy as the underlying data storage solution. It inherits from the
-    `AbstractUnitOfWork` class and provides the concrete implementations of the
-    `commit` and `rollback` methods.
-
-    Attributes:
-        session (sqlalchemy.orm.Session): The SQLAlchemy session used for
-            database transactions.
+        interfaces (BlockDeviceSqlAlchemyRepository): Repository for
+            ISCSIInterface entities.
     """
 
     def __init__(self, session_factory: sessionmaker = DEFAULT_SESSION_FACTORY):
-        """Initialize the SqlAlchemyUnitOfWork.
+        """Initializes the Unit of Work with a session factory.
 
         Args:
-            session_factory (callable, optional): A factory function that
-                returns a SQLAlchemy session.
-                Defaults to `DEFAULT_SESSION_FACTORY`.
+            session_factory (sessionmaker): SQLAlchemy session factory.
+                Defaults to DEFAULT_SESSION_FACTORY.
         """
-        self.session_factory = session_factory
-        self.session: Session
+        super().__init__(session_factory)
 
-    def __enter__(self) -> AbstractUnitOfWork:
-        """Enter the unit of work context, initializing the repository."""
-        self.session = self.session_factory()
-        self.interfaces = repository.SqlAlchemyRepository(self.session)
-        return super().__enter__()
-
-    def __exit__(self, *args: Any) -> None:  # noqa: ANN401 # TODO need to parameterize the arguments correctly, in accordance with static typing
-        """Exit the unit of work context, performing a rollback if necessary."""
-        super().__exit__(*args)
-        self.session.close()
-
-    def commit(self) -> None:
-        """Commit the current database transaction."""
-        self.session.commit()
-
-    def rollback(self) -> None:
-        """Roll back the current database transaction."""
-        self.session.rollback()
+    def _init_repositories(self) -> None:
+        """Initializes repositories for the block_device module."""
+        self.interfaces = repository.BlockDeviceSqlAlchemyRepository(
+            self.session
+        )


### PR DESCRIPTION
# Описание изменений

Перевод Unit of Work и repository модуля block_device на использование базовых общих абстракций BaseSqlAlchemyRepository и BaseSqlAlchemyUnitOfWork

# Ключевые изменения

- Удалены абстрактные классы AbstractUnitOfWork и AbstractRepository, от которых наследовались repository и unit_of_work
- Удалены методы, дублирующие логику абстрактных классов BaseSqlAlchemyRepository и BaseSqlAlchemyUnitOfWork
- Изменена инициализация uow и его использование в контекстном менеджере with в файле service.py
- Обновлена работа с контекстным менеджером в файле service.py: соблюдён принцип "одно действие - один коммит и закрытие контекста".
- Изменён тип входных данных в функции _rollback service.py, тк для функции delete_by_id требуется uuid, а не строка. 
- Обновлён BlockDeviceServiceLayerManager, так чтобы он использовал новый uow