### PR TITLE
Doc install update

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -694,8 +694,8 @@ install_restic(){
 }
 
 install_uv(){
-  local install_uv_command="sudo python3 -m pip install -U uv"
-  local install_message="Installing uv"
+  local install_uv_command="curl -LsSf https://astral.sh/uv/install.sh | sh"
+  local install_message="Installing uv via official installer"
   execute "$install_uv_command" "$install_message"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -694,7 +694,7 @@ install_restic(){
 }
 
 install_uv(){
-  local install_uv_command="python3 -m pip install -U uv"
+  local install_uv_command="sudo python3 -m pip install -U uv"
   local install_message="Installing uv"
   execute "$install_uv_command" "$insatll_message"
 }

--- a/install.sh
+++ b/install.sh
@@ -693,12 +693,18 @@ install_restic(){
   execute "$self_update_command" "$update_message"
 }
 
+install_uv(){
+  local install_uv_command="python3 -m pip install -U uv"
+  local insatll_message="Installing uv"
+  execute "$install_uv_command" "$insatll_message"
+}
+
 install_documentation(){
   local doc_repo="https://github.com/Aerodisk/openvair-docs.git"
 
   local clone_docs_repo="git clone $doc_repo"
   local clone_message="Cloning documentation repository..."
-  
+
   local install_docs="bash $DOCS_PROJECT_PATH/install.sh"
   local install_docs_message="Installing documentation..."
 
@@ -706,9 +712,8 @@ install_documentation(){
     log $GREEN "Documentation repository already exists at $DOCS_PROJECT_PATH"
   else
     execute "$clone_docs_repo" "$clone_message"
-    execute "cd $DOCS_PROJECT_PATH" "Changing directory to $DOCS_PROJECT_PATH"
-    execute "$install_docs" "$install_docs_message"
   fi
+  execute "$install_docs" "$install_docs_message"
 
   go_to_home_dir
 }
@@ -862,6 +867,7 @@ main() {
     clear_home_dir
     make_hashed_password
     create_default_user
+    install_uv
     install_documentation
     restart_service 'web-app.service'
     print_final_message

--- a/install.sh
+++ b/install.sh
@@ -697,6 +697,10 @@ install_uv(){
   local install_uv_command="curl -LsSf https://astral.sh/uv/install.sh | sh"
   local install_message="Installing uv via official installer"
   execute "$install_uv_command" "$install_message"
+  
+  # Add uv to PATH for current session
+  export PATH="$HOME/.local/bin:$PATH"
+  log $GREEN "Added uv to PATH for current session"
 }
 
 install_documentation(){

--- a/install.sh
+++ b/install.sh
@@ -696,7 +696,7 @@ install_restic(){
 install_uv(){
   local install_uv_command="sudo python3 -m pip install -U uv"
   local install_message="Installing uv"
-  execute "$install_uv_command" "$insatll_message"
+  execute "$install_uv_command" "$install_message"
 }
 
 install_documentation(){

--- a/install.sh
+++ b/install.sh
@@ -695,7 +695,7 @@ install_restic(){
 
 install_uv(){
   local install_uv_command="python3 -m pip install -U uv"
-  local insatll_message="Installing uv"
+  local install_message="Installing uv"
   execute "$install_uv_command" "$insatll_message"
 }
 

--- a/openvair/main.py
+++ b/openvair/main.py
@@ -109,6 +109,11 @@ app.include_router(tempalte_router)
 project_dir = Path(__file__).parent
 templates = Jinja2Templates(directory=project_dir / 'dist')
 app.mount('/assets', StaticFiles(directory=project_dir / 'dist/assets'))
+app.mount(
+    '/docs',
+    StaticFiles(directory=project_dir.parent / 'docs', html=True),
+    name='mkdocs_docs',
+)
 
 
 @app.middleware('http')


### PR DESCRIPTION
# **Описание изменений**

После перехода документации с Sphinx на MkDocs обновлён инсталлятор и веб-приложение для корректной установки и публикации собранных файлов.

---

## **Изменения в `install.sh`**
- Добавлена функция `install_uv` для установки/обновления `uv`:
  ```bash
  install_uv(){
    local install_uv_command="python3 -m pip install -U uv"
    local install_message="Installing uv"
    execute "$install_uv_command" "$install_message"
  }
  ```
- В `install_documentation`:
  - Репозиторий документации (`openvair-docs`) клонируется только при отсутствии локальной копии.
  - Скрипт установки документации теперь вызывается всегда.
  - Удалён лишний `cd`.
- Вызов `install_uv` добавлен в `main()` перед установкой документации.
- Основная логика билда и установки находится в проекте документации: https://github.com/Aerodisk/openvair-docs/blob/main/install.sh


---

## **Изменения в `openvair/main.py`**
- Добавлен роут `/docs` для раздачи статических файлов собранной документации MkDocs:
  ```python
  app.mount(
      '/docs',
      StaticFiles(directory=project_dir.parent / 'docs', html=True),
      name='mkdocs_docs',
  )
  ```

---

# **Критерии приёмки**
- `install.sh`:
  - Устанавливает/обновляет `uv`.
  - Клонирует или обновляет документацию и выполняет её установку.
- Приложение корректно отдаёт документацию по `/docs`.

---

# **План тестирования**
1. **Чистая установка** — проверить установку `uv`, сборку документации, доступность `/docs`.
2. **Повторная установка** — убедиться, что репозиторий не клонируется повторно, но документация пересобирается.
3. **Проверка `/docs`** — открыть в браузере, убедиться в корректной загрузке контента.
