### PR TITLE
FIX: Virtual Machines. Добавление проверки уникальности дисков, прикрепляемых к ВМ

### DIFF
--- a/openvair/modules/virtual_machines/service_layer/exceptions.py
+++ b/openvair/modules/virtual_machines/service_layer/exceptions.py
@@ -140,3 +140,10 @@ class SnapshotNotFoundException(BaseCustomException):
     def __init__(self, message: str, *args: Any) -> None: # noqa: ANN401 # TODO need to parameterize the arguments correctly, in accordance with static typing
         """Initialize SnapshotNotFoundException with optional arguments."""
         super().__init__(message, *args)
+
+
+class DuplicateDiskException(BaseCustomException):
+    """Raised when trying to attach duplicate disk to VM"""
+    def __init__(self, message: str, *args: Any) -> None: # noqa: ANN401 # TODO need to parameterize the arguments correctly, in accordance with static typing
+        """Initialize DuplicateDiskException with optional arguments."""
+        super().__init__(message, *args)

--- a/openvair/modules/virtual_machines/service_layer/services.py
+++ b/openvair/modules/virtual_machines/service_layer/services.py
@@ -1378,7 +1378,7 @@ class VMServiceLayerManager(BackgroundTasks):
             try:
                 self._process_vm_volumes(vm_edit_info, vm_id, user_info)
             except exceptions.DuplicateDiskException as err:
-                message = f'Handle error: {err!s} while editing VM disks.'
+                message = f'Handle error while processing VM disks: {err!s}.'
                 LOG.error(message)
                 db_vm.information = message
             finally:


### PR DESCRIPTION
# Описание изменений

В модуле **Virtual Machines** добавлена проверка уникальности дисков, прикрепляемых (в т.ч. с созданием томов) к виртуальной машине при создании и редактировании ВМ через API. Теперь система предотвращает добавление дубликатов дисков: при создании ВМ - выводится соответствующая ошибка и создание ВМ не происходит, при редактировании ВМ - 

---

# Основные изменения

1. **Новое исключение** сервисного модуля ВМ:
   - Добавлено исключение `DuplicateDiskException` для обработки случаев дублирования дисков

2. Проверка дубликатов при **создании ВМ**:
   - В методе `_prepare_create_vm_info` добавлена валидация уникальности дисков в запросе по `disk_id`
   - Подготовка данных вынесена до RPC-вызова - при ошибке пользователю возвращается ответ с указанием на ошибку, создание ВМ не происходит
   - Пример ошибки: `Multiple attachment of disk {disk_id} in the request`
<img width="1219" height="295" alt="image" src="https://github.com/user-attachments/assets/5e5fd214-b852-4a0c-a330-d02d51d55c41" />



3. Проверка дубликатов при **редактировании ВМ**:
   - Аналогичная проверка добавлена в `_prepare_vm_info_for_edit()`
   - Ошибка не возвращается пользователю из-за асинхронности метода (`rpc cast`) 
   - Сообщение об ошибке записывается в поле `information` виртуальной машины
<img width="593" height="148" alt="image" src="https://github.com/user-attachments/assets/74d23e73-79c4-41f0-881d-cde71b0706f8" />



4. **Проверка при прикреплении дисков**:
   - В методе `_add_disks_to_vm` добавлена проверка конфликтов с уже существующими дисками перед сохранением в БД
   - Пример ошибки: `Disk {disk_id} is already attached to this VM`
<img width="562" height="80" alt="image" src="https://github.com/user-attachments/assets/0e29d1ac-c78e-44da-b052-2b9e2655e7dc" />



5. **Обработка ошибок**:
   - `DuplicateDiskException` обрабатывается в методах `create_vm` и `edit_vm`
   - При редактировании ошибки сохраняются в поле `information` ВМ
   - Добавлена безопасная обработка ошибок при создании томов в `_create_volume()` (конструкция `try-except` для корректной обработки ошибки из сервисного слоя volume)

---

# Требования к тестированию

1. **Создание ВМ с дубликатом диска в запросе**:
   - Попытка создать ВМ с одинаковыми `volume` или `image` в `attach_disks`
   - Ожидание: ошибка `DuplicateDiskException` на этапе создания

2. **Редактирование ВМ с дубликатом диска в запросе**:
   - Попытка добавить одинаковые `volume` или `image` в `attach_disks` при редактировании ВМ
   - Ожидание: ошибка с сохранением в поле `information` ВМ

3. **Добавление уже прикрепленного диска**:
   - Попытка прикрепить диск, который уже прикреплён к ВМ
   - Ожидание: ошибка на этапе прикрепления (`_add_disks_to_vm`)

4. **Успешные сценарии**:
   - Создание/редактирование ВМ с уникальными дисками (в том числе создание `volume` при прикреплении)

---

# Связанные задачи

- **Issue** #231 

---

# Критерии приёмки

- [x] При попытке добавить дубликат диска при создании или редактировании ВМ пользователь получает ошибку с понятным сообщением (при создании - в ответе, при редактировании - в поле `information` ВМ)
- [x] Система предотвращает добавление к ВМ диска, уже прикрепленного к данной ВМ
- [x] Корректно обрабатываются ошибки создания тома (сервисного слоя volume) при создании/редактировании ВМ.
- [x] Ошибки не мешают успешному созданию/редактированию ВМ с корректными данными