### PR TITLE
Tests: Volume. Рефакторинг тестов API модуля 

### DIFF
--- a/openvair/conftest.py
+++ b/openvair/conftest.py
@@ -130,7 +130,7 @@ def configure_pagination() -> None:
 
 
 @pytest.fixture(scope='module')
-def storage(client: TestClient) -> Generator[dict, None, None]:
+def storage(client: TestClient) -> Generator[Dict, None, None]:
     """Creates a test storage and deletes it after session ends."""
     headers = {'Authorization': 'Bearer mocked_token'}
 
@@ -170,7 +170,7 @@ def storage(client: TestClient) -> Generator[dict, None, None]:
 
 
 @pytest.fixture(scope='function')
-def volume(client: TestClient, storage: dict) -> Generator[dict, None, None]:
+def volume(client: TestClient, storage: Dict) -> Generator[Dict, None, None]:
     """Creates a test volume and deletes it after each test."""
     volume_data = CreateVolume(
         name=generate_test_entity_name('volume'),

--- a/openvair/libs/testing/utils.py
+++ b/openvair/libs/testing/utils.py
@@ -33,7 +33,7 @@ LOG = get_logger(__name__)
 
 
 def create_resource(
-    client: TestClient, endpoint: str, payload: dict, resource_name: str
+    client: TestClient, endpoint: str, payload: Dict, resource_name: str
 ) -> Dict[str, Any]:
     """Creates a resource on a specified endpoint using the provided client and payload.
 
@@ -191,7 +191,7 @@ def wait_for_field_value(  # noqa: PLR0913
             raw = response.json()
             data = (
                 raw['data']
-                if 'data' in raw and isinstance(raw['data'], dict)
+                if 'data' in raw and isinstance(raw['data'], Dict)
                 else raw
             )
             if data.get(field) == expected:
@@ -262,7 +262,7 @@ def wait_full_deleting(
             raw = response.json()
             data = (
                 raw['data']
-                if 'data' in raw and isinstance(raw['data'], dict)
+                if 'data' in raw and isinstance(raw['data'], Dict)
                 else raw
             )
             if data.get(object_id) is None:
@@ -277,6 +277,6 @@ def wait_full_deleting(
 
 def _extract_data_field(response_json: Dict) -> Dict:
     """Returns response['data'] if it's a BaseResponse, else root object."""
-    if 'data' in response_json and isinstance(response_json['data'], dict):
+    if 'data' in response_json and isinstance(response_json['data'], Dict):
         return response_json['data']
     return response_json

--- a/openvair/modules/volume/tests/api/test_create.py
+++ b/openvair/modules/volume/tests/api/test_create.py
@@ -197,7 +197,25 @@ def test_create_volume_with_nonexistent_storage(client: TestClient) -> None:
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert (
         'storage' in response.text.lower()
-    )  # Сообщение о несуществующем хранилище  # noqa: RUF003
+    )  # Сообщение о несуществующем хранилище # noqa: RUF003
+
+
+def test_create_volume_unauthorized(
+        unauthorized_client: TestClient, storage: Dict
+) -> None:
+    """Test unauthorized request returns 401."""
+    volume_data = CreateVolume(
+        name=generate_test_entity_name('volume'),
+        description='Unauthorized test',
+        storage_id=storage['id'],
+        format='qcow2',
+        size=1024,
+        read_only=False,
+    )
+    response = unauthorized_client.post(
+        '/volumes/create/', json=volume_data.model_dump(mode='json')
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_create_volume_from_template_success(

--- a/openvair/modules/volume/tests/conftest.py
+++ b/openvair/modules/volume/tests/conftest.py
@@ -13,7 +13,7 @@ Includes:
 """
 
 from uuid import UUID, uuid4
-from typing import Generator
+from typing import Dict, Generator
 
 import pytest
 
@@ -27,7 +27,7 @@ LOG = get_logger(__name__)
 
 
 @pytest.fixture(scope='function')
-def attached_volume(volume: dict) -> Generator[dict, None, None]:
+def attached_volume(volume: Dict) -> Generator[Dict, None, None]:
     """Creates volume-to-VM attachment (directly in DB) and removes it after test."""  # noqa: E501
     volume_id = UUID(volume['id'])
     vm_id = uuid4()


### PR DESCRIPTION
# Описание изменений

В данном PR была проведена ревизия и рефакторинг интеграционных тестов API модуля **_Volume_**. Добавлены тесты для проверки неавторизованного запроса. Типизация приведена к общему стандарту проекта.

Было проверено покрытие тестами различных эндпоинтов API и их edge-кейсов.


# Ключевые изменения

Покрытие тестами:
    - test_create.py - покрыты `POST /volumes/create/` и `POST /volumes/from_template/`
    - test_delete.py - покрыт `DELETE /volumes/{volume_id}/`
    - test_edit.py - покрыт `PUT /volumes/{volume_id}/edit/`
    - test_extend.py - покрыт `POST /volumes/{volume_id}/extend/`
    - test_retrieve.py - покрыты `GET /volumes/` и `GET /volumes/{volume_id}/`

Ко всем эндпоинтам был добавлен тест на неавторизованный запрос (`unauthorized request - HTTP 401`).

Для приведения к общей типизации проекта использования в тестах и фикстурах типов `dict` и `list` заменены на `typing.Dict` и `typing.List` соответственно.

_**Важно:**_ 
Эндпоинты `POST /volumes/{volume_id}/attach/` и `DELETE /volumes/{volume_id}/detach/` являются устаревшими и будут удалены в ближайшее время, их покрытие не требуется.


# Критерии приёмки

- [x] Проведён рефакторинг тестов
- [x] Покрыты все эндпоинты API, их основные ошибки и edge-кейсы
- [x] Все тесты стабильно проходят успешно
- [x] Документация актуальна, её обновление не требуется


# Связанные задачи

- Issue #247 