### PR TITLE
Refactor: Virtual Machines. Замена возвращаемого типа `get_vm_snapshots()` с Tuple на Dict

### DIFF
--- a/openvair/libs/libvirt/vm.py
+++ b/openvair/libs/libvirt/vm.py
@@ -15,7 +15,7 @@ Functions:
     current snapshot name.
 """
 
-from typing import Set, Dict, Tuple, Optional
+from typing import Dict
 
 import libvirt
 
@@ -45,16 +45,16 @@ def get_vms_state() -> Dict[str, str]:
     return vms
 
 
-def get_vm_snapshots(vm_name: str) -> Tuple[Set[str], Optional[str]]:
+def get_vm_snapshots(vm_name: str) -> Dict:
     """Get all snapshots for a VM and its current snapshot name.
 
     Args:
         vm_name: Name of the virtual machine to check.
 
     Returns:
-        Tuple: (Set(str), Optional(str)) - tuple containing:
-        - Set of all snapshot names
-        - Name of current snapshot (None if no current snapshot)
+        Dict:
+            'snapshots': Set of all snapshot names
+            'current_snapshot': Name of current snapshot (None if no current)
     """
     with CONNECTION as conn:
         try:
@@ -62,13 +62,13 @@ def get_vm_snapshots(vm_name: str) -> Tuple[Set[str], Optional[str]]:
             snapshots = domain.listAllSnapshots()
             snap_names = {snap.getName() for snap in snapshots}
             if not snapshots:
-                return set(), None
+                return {'snapshots': set(), 'current_snapshot': None}
             try:
                 current_snap = domain.snapshotCurrent()
                 current_name = current_snap.getName() if current_snap else None
             except libvirt.libvirtError:
                 current_name = None
         except libvirt.libvirtError:
-            return set(), None
+            return {'snapshots': set(), 'current_snapshot': None}
         else:
-            return snap_names, current_name
+            return {'snapshots': snap_names, 'current_snapshot': current_name}

--- a/openvair/modules/virtual_machines/service_layer/services.py
+++ b/openvair/modules/virtual_machines/service_layer/services.py
@@ -2223,7 +2223,9 @@ class VMServiceLayerManager(BackgroundTasks):
         Args:
             db_vm: VirtualMachines database object to update snapshots for.
         """
-        libvirt_snaps, libvirt_current_snap = get_vm_snapshots(db_vm.name)
+        snapshots_info = get_vm_snapshots(db_vm.name)
+        libvirt_snaps = snapshots_info['snapshots']
+        libvirt_current_snap = snapshots_info['current_snapshot']
         vm_id = str(db_vm.id)
         with self.uow() as uow:
             db_snaps = uow.snapshots.get_all_by_vm(vm_id)


### PR DESCRIPTION
# Описание изменений

Изменена функция `get_vm_snapshots` в `openvair.libs.libvirt.vm` - заменён возвращаемый тип с `Tuple` на `Dict` для улучшения читаемости и поддерживаемости кода.

---

# Основные изменения

- Функция `get_vm_snapshots()` теперь возвращает словарь вместо кортежа
- Структура возвращаемых данных:
  - `'snapshots'`: множество (`set`) имён всех снапшотов _libvirt_
  - `'current_snapshot'`: имя текущего (`current`) снапшота (или `None`) _libvirt_
- Пример возвращаемого значения функции:
   ```python
   return {'snapshots': snap_names, 'current_snapshot': current_name}
   ```
- Обновлен _docstring_ функции с описанием новой структуры возвращаемых данных
- В сервисном слое обновлён способ получения данных, теперь - по ключу словаря:
  ```python
  # Было:
  libvirt_snaps, libvirt_current_snap = get_vm_snapshots(db_vm.name)
  
  # Стало:
  snapshots_info = get_vm_snapshots(db_vm.name)
  libvirt_snaps = snapshots_info['snapshots']
  libvirt_current_snap = snapshots_info['current_snapshot']
  ```

---

# Требования к тестированию
- Убедиться, что функция `get_vm_snapshots` корректно возвращает информацию о снапшотах ВМ из _libvirt_
- Проверить, что обновлённый код сервисного слоя правильно извлекает данные из словаря
- Убедиться, что вся функциональность работы со снапшотами сохранилась (мониторинг)
- Обновить (в соответствии с новым использованием функции) и запустить тесты API модуля виртуальных машин

---

# Связанные задачи
- **Issue** #281 

---

# Критерии приёмки
- [x] Функция возвращает данные в новом формате (словарь `Dict`)
- [x] Код корректно работает с обновлённым форматом данных, сохранена обратная совместимость
- [x] Код стал более понятным и очевидным
- [x] Автоматизированные тесты API модуля ВМ успешно проходят (после обновления)