### PR TITLE
Refactor: Virtual Machines. Формат вызова `get_vm_snapshots()` в тестах модуля

### DIFF
--- a/openvair/modules/virtual_machines/tests/api/snapshots/test_snap_create.py
+++ b/openvair/modules/virtual_machines/tests/api/snapshots/test_snap_create.py
@@ -73,9 +73,11 @@ def test_create_snapshot_success(
     ).json()
     assert created_snapshot['status'] == 'running'
     assert created_snapshot['is_current'] is True
-    libvirt_snapshots, current_snapshot = get_vm_snapshots(vm_name)
+    libvirt_snapshots_info = get_vm_snapshots(vm_name)
+    libvirt_snapshots = libvirt_snapshots_info['snapshots']
+    libvirt_current_snapshot = libvirt_snapshots_info['current_snapshot']
     assert snapshot_data['name'] in libvirt_snapshots
-    assert current_snapshot == snapshot_data['name']
+    assert libvirt_current_snapshot == snapshot_data['name']
 
 
 def test_create_snapshot_missing_name(
@@ -224,8 +226,10 @@ def test_create_multiple_snapshots_chain(
             'running',
         )
 
-    libvirt_snapshots, current_snapshot = get_vm_snapshots(vm_name)
-    assert current_snapshot == f'chain_snapshot_{snapshots_num-1}'
+    libvirt_snapshots_info = get_vm_snapshots(vm_name)
+    libvirt_snapshots = libvirt_snapshots_info['snapshots']
+    libvirt_current_snapshot = libvirt_snapshots_info['current_snapshot']
+    assert libvirt_current_snapshot == f'chain_snapshot_{snapshots_num-1}'
 
     for i, snapshot in enumerate(snapshots):
         snapshot_details = client.get(

--- a/openvair/modules/virtual_machines/tests/api/snapshots/test_snap_delete.py
+++ b/openvair/modules/virtual_machines/tests/api/snapshots/test_snap_delete.py
@@ -32,7 +32,8 @@ def test_delete_snapshot_success(
     vm_name = activated_virtual_machine['name']
     snapshot_id = vm_snapshot['id']
     snapshot_name = vm_snapshot['name']
-    libvirt_snapshots, libvirt_current = get_vm_snapshots(vm_name)
+    libvirt_snapshots_info = get_vm_snapshots(vm_name)
+    libvirt_snapshots = libvirt_snapshots_info['snapshots']
     assert snapshot_name in libvirt_snapshots
 
     response = client.delete(
@@ -50,9 +51,11 @@ def test_delete_snapshot_success(
     assert response.status_code == status.HTTP_200_OK
     list_data = response.json()
     assert len(list_data['snapshots']) == 0
-    final_libvirt_snapshots, final_libvirt_current = get_vm_snapshots(vm_name)
-    assert snapshot_name not in final_libvirt_snapshots
-    assert final_libvirt_current is None
+    libvirt_snapshots_info = get_vm_snapshots(vm_name)
+    libvirt_snapshots = libvirt_snapshots_info['snapshots']
+    libvirt_current_snapshot = libvirt_snapshots_info['current_snapshot']
+    assert snapshot_name not in libvirt_snapshots
+    assert libvirt_current_snapshot is None
     with VMSqlAlchemyUnitOfWork() as uow:
         assert not uow.snapshots.get(snapshot_id)
 
@@ -139,7 +142,8 @@ def test_delete_snapshot_chain_success(
     assert snap1['name'] in remaining_snapshot_names
     assert snap3['name'] in remaining_snapshot_names
     assert snap2['name'] not in remaining_snapshot_names
-    libvirt_snapshots, current_snapshot = get_vm_snapshots(vm_name)
+    libvirt_snapshots_info = get_vm_snapshots(vm_name)
+    libvirt_snapshots = libvirt_snapshots_info['snapshots']
     assert snap1['name'] in libvirt_snapshots
     assert snap3['name'] in libvirt_snapshots
     assert snap2['name'] not in libvirt_snapshots

--- a/openvair/modules/virtual_machines/tests/api/snapshots/test_snap_manage.py
+++ b/openvair/modules/virtual_machines/tests/api/snapshots/test_snap_manage.py
@@ -55,9 +55,11 @@ def test_revert_snapshot_success(
     ).json()
     assert final_snapshot['status'] == 'running'
     assert final_snapshot['is_current'] is True
-    libvirt_snapshots, current_snapshot = get_vm_snapshots(vm_name)
+    libvirt_snapshots_info = get_vm_snapshots(vm_name)
+    libvirt_snapshots = libvirt_snapshots_info['snapshots']
+    libvirt_current_snapshot = libvirt_snapshots_info['current_snapshot']
     assert final_snapshot['name'] in libvirt_snapshots
-    assert current_snapshot == snapshot_name
+    assert libvirt_current_snapshot == snapshot_name
 
 
 def test_revert_snapshot_chain_success(
@@ -118,8 +120,9 @@ def test_revert_snapshot_chain_success(
         f'/virtual-machines/{vm_id}/snapshots/{snap1["id"]}'
     ).json()
     assert snap1_after['is_current'] is True
-    libvirt_snapshots, current_snapshot = get_vm_snapshots(vm_name)
-    assert current_snapshot == snap1['name']
+    libvirt_snapshots_info = get_vm_snapshots(vm_name)
+    libvirt_current_snapshot = libvirt_snapshots_info['current_snapshot']
+    assert libvirt_current_snapshot == snap1['name']
 
 
 def test_revert_snapshot_shutoff_vm(

--- a/openvair/modules/virtual_machines/tests/api/virtual_machines/test_manage.py
+++ b/openvair/modules/virtual_machines/tests/api/virtual_machines/test_manage.py
@@ -201,9 +201,11 @@ def test_vm_restart_with_snapshot(
     initial_snapshot = initial_snapshot_response.json()
     assert initial_snapshot['status'] == 'running'
     assert initial_snapshot['is_current'] is True
-    initial_libvirt_snapshots, initial_current = get_vm_snapshots(vm_name)
-    assert snapshot_name in initial_libvirt_snapshots
-    assert initial_current == snapshot_name
+    libvirt_snapshots_info = get_vm_snapshots(vm_name)
+    libvirt_snapshots = libvirt_snapshots_info['snapshots']
+    libvirt_current_snapshot = libvirt_snapshots_info['current_snapshot']
+    assert snapshot_name in libvirt_snapshots
+    assert libvirt_current_snapshot == snapshot_name
 
     # Shut down VM
     shutdown_response = client.post(f'/virtual-machines/{vm_id}/shut-off/')
@@ -242,6 +244,8 @@ def test_vm_restart_with_snapshot(
         'running',
         timeout=SNAPSHOT_TIMEOUT,
     )
-    restored_libvirt_snapshots, restored_current = get_vm_snapshots(vm_name)
-    assert snapshot_name in restored_libvirt_snapshots
-    assert restored_current == snapshot_name
+    libvirt_snapshots_info = get_vm_snapshots(vm_name)
+    libvirt_snapshots = libvirt_snapshots_info['snapshots']
+    libvirt_current_snapshot = libvirt_snapshots_info['current_snapshot']
+    assert snapshot_name in libvirt_snapshots
+    assert libvirt_current_snapshot == snapshot_name


### PR DESCRIPTION
# Описание изменений

Изменено использовании функции `get_vm_snapshots()` из `openvair.libs.libvirt.vm` в тестах модуля виртуальных машин после изменения возвращаемого типа в PR #287.

---

# Основные изменения

- Функция `get_vm_snapshots()` теперь возвращает словарь вместо кортежа, поэтому в тестах обновлён способ получения данных, теперь - по ключам словаря:
  ```python
  # Было:
  libvirt_snapshots, current_snapshot = get_vm_snapshots(vm_name)
  
  # Стало:
  libvirt_snapshots_info = get_vm_snapshots(vm_name)
  libvirt_snapshots = libvirt_snapshots_info['snapshots']
  libvirt_current_snapshot = libvirt_snapshots_info['current_snapshot']
  ```

---

# Связанные задачи
- **Issue** #281 

---

# Критерии приёмки
- [x] Код корректно работает с обновлённым форматом данных, сохранена обратная совместимость
- [x] Код стал более понятным и очевидным
- [x] Автоматизированные тесты API модуля ВМ (**в частности - тесты снапшотов**) успешно проходят
