### PR TITLE
Add always_run: true for RDE-Linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,5 +15,5 @@ repos:
       name: RDE Markdown specs
       entry: bash .githooks/rde-linter
       language: system
-      files: ^specs/
+      always_run: true
       pass_filenames: false


### PR DESCRIPTION
@tihon49 забыл убрать из .pre-commit-config.yaml неправильное условие срабатывания линтера. Сейчас он срабатывает только при внесении изменений в папку с ТЗ. Нужно, чтобы он всегда прогонялся.